### PR TITLE
feat: bootstrap mac-care CLI with OSS integrations and git practices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,21 @@
+---
+name: Bug
+about: Something that isn't working as expected
+title: "bug(scope): "
+labels: bug
+---
+
+## Description
+
+## Steps to Reproduce
+1.
+2.
+
+## Expected Behaviour
+
+## Actual Behaviour
+
+## Environment
+- macOS version:
+- Python version:
+- mac-care version:

--- a/.github/ISSUE_TEMPLATE/enabler.md
+++ b/.github/ISSUE_TEMPLATE/enabler.md
@@ -1,0 +1,16 @@
+---
+name: Enabler
+about: Technical foundation or prerequisite work
+title: "enabler(scope): "
+labels: enabler
+---
+
+## Description
+
+## Acceptance Criteria
+- [ ]
+
+## Non-goals
+
+## Parent
+<!-- #epic-number if applicable -->

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,16 @@
+---
+name: Epic
+about: Parent outcome spanning multiple child issues
+title: "epic(scope): "
+labels: epic
+---
+
+## Description
+
+## Child Issues
+- [ ]
+
+## Acceptance Criteria
+- [ ]
+
+## Non-goals

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,16 @@
+---
+name: Story
+about: User-facing feature or improvement
+title: "story(scope): "
+labels: story
+---
+
+## Description
+
+## Acceptance Criteria
+- [ ]
+
+## Non-goals
+
+## Parent
+<!-- #epic-number if applicable -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What
+<!-- One line summary -->
+
+## Why
+<!-- Context — which item / issue does this close -->
+Closes #
+
+## Changes
+<!-- Per-file summary of what changed and why -->
+-
+
+## Validation
+- [ ] `python -m pytest tests/` passes
+- [ ] dry-run verified (no files deleted)
+- [ ] protected paths respected
+- [ ] new module has at least one test
+
+## Risks / Follow-ups
+<!-- Anything that needs a follow-up issue or further review -->

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install package
-        run: pip install -e .
+        run: pip install -e ".[dev]"
 
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,20 @@
 
 Build a free, local macOS maintenance tool for Deepankar's developer machine.
 
-This project should replace the useful operational parts of CleanMyMac without copying its UI or building risky one-click cleanup behavior.
+This project replaces the useful operational parts of CleanMyMac without copying its UI or building risky one-click cleanup behaviour.
+
+## Source of Truth
+
+Use this priority order when instructions conflict:
+1. Direct user instruction
+2. This `AGENTS.md`
+3. GitHub Issues (`https://github.com/djspiceroute/mac-care/issues`)
+4. Existing code patterns
+5. Tool or framework defaults
 
 ## Defaults
 
-- Prefer report-first behavior over deletion.
+- Prefer report-first behaviour over deletion.
 - Never add broad `rm -rf` cleanup.
 - Keep destructive actions behind explicit flags and dry-run output.
 - Preserve developer work by default.
@@ -34,16 +43,142 @@ Do not auto-delete these unless the user explicitly changes config:
 - `src/mac_care/doctor.py`: developer tool and environment checks
 - `src/mac_care/clean.py`: safe cleanup orchestration
 - `src/mac_care/report.py`: Markdown and JSON reports
+- `src/mac_care/git_safety.py`: git repo / worktree safety gate
+- `src/mac_care/scheduler.py`: launchd schedule install/uninstall
 - `src/mac_care/tools/`: wrappers for external OSS utilities
+  - `brew.py`: Homebrew cleanup findings
+  - `disk.py`: dua/dust disk tree integration
+  - `docker_check.py`: Docker disk usage findings
+  - `pearcleaner.py`: orphaned app support file findings
 
 ## Open-Source Utility Strategy
 
-Use existing tools where practical:
+mac-care is an orchestrator, not a scanner. Use existing tools where practical and parse their output into `Finding` objects. Write policy, scheduling, reporting, protected paths, and approval flow — not commodity scanners.
 
-- `gdu`, `ncdu`, `dust`, or `dua` for disk usage
-- Homebrew for package cache/update checks
-- Docker/OrbStack CLI for container cleanup reports
-- Objective-See tools for security/persistence visibility
-- Mole, ClearDisk, Pearcleaner, or similar tools only after scan-only evaluation
+Preferred tools:
+- `dua` (primary) / `dust` / `gdu` / `ncdu` for disk usage trees
+- `brew cleanup --dry-run` for Homebrew cache analysis
+- `docker system df` for container/image/volume waste
+- `pearcleaner --list-orphans` for orphaned app support files
+- Objective-See tools (KnockKnock) for security/persistence visibility — future
 
-The custom code should focus on policy, scheduling, reporting, protected paths, and approval flow.
+Each wrapper in `tools/` must:
+1. Check if the tool is installed (`shutil.which`) before calling it
+2. Degrade gracefully — return `[]` if the tool is absent, never raise
+3. Never inline `subprocess` calls outside `tools/`
+4. Be independently testable with mocked subprocess output
+
+## Branch Naming
+
+Always prefix with agent identity, lowercase, followed by a slash and short descriptor:
+
+```
+claude/git-safety
+claude/brew-integration
+codex/docker-findings
+```
+
+Never create a branch without an agent prefix unless the user explicitly requests it.
+
+## Git Workflow
+
+- Work on a branch — never commit directly to `main`
+- Use git worktrees for multi-file items to keep work isolated:
+  ```bash
+  git worktree add ../mac-care-<agent>-<task> -b <agent>/<task>
+  ```
+- Rebase on `main` before opening a PR:
+  ```bash
+  git fetch origin && git rebase origin/main
+  ```
+- **Local commits are allowed after each item passes tests** — no need to ask
+- **Never push without explicit user instruction**
+- Never force-push `main`
+- Remove worktrees after branch is merged:
+  ```bash
+  git worktree remove ../mac-care-<agent>-<task>
+  ```
+
+## Commit Message Convention
+
+Use Conventional Commits format:
+```
+feat(scan): add brew cleanup integration
+fix(doctor): handle missing PATH for homebrew
+test(git_safety): add dirty-repo detection tests
+chore(infra): add GitHub Actions test workflow
+docs(agents): update architecture and git policies
+```
+
+Types: `feat`, `fix`, `test`, `chore`, `docs`, `refactor`
+
+## Standard Workflow
+
+1. Read `AGENTS.md` and relevant source files before starting
+2. Confirm scope — escalate if ambiguous rather than guessing
+3. Implement the narrowest change that fully solves the problem
+4. Run `python -m pytest tests/` — do not claim validation without running it
+5. Update docs if behaviour, setup, or contracts changed
+6. Summarise: what changed / files touched / validation performed / risks / next steps
+
+## Testing Rules
+
+- Every new module gets at least one unit test
+- Tests never touch the real filesystem — use `tmp_path` (pytest) or `tempfile`
+- Tests never call real external tools — mock all `subprocess` calls
+- Tests must run in under 5 seconds total
+- Clearly state when tests could not run and why
+
+## Dependency Rules
+
+Only add a Python dependency to `pyproject.toml` if all are true:
+1. The stdlib cannot reasonably solve the task
+2. It materially reduces complexity
+3. It is mature and well-maintained
+4. The maintenance cost is justified
+
+If added, justify it in the PR body. External binaries (`brew`, `dua`, `docker`, etc.) are not Python dependencies — they are optional integrations.
+
+## Safety Rules
+
+- `dry_run=True` is the default for all clean operations
+- Protected paths are checked before every action, not just at scan time
+- Never `rm -rf` — quarantine dir (`~/Documents/MacCare/quarantine/`) is the deletion target
+- Git safety gate (`git_safety.py`) must run before any action touching workspace directories
+- `auto_safe` is the only risk level eligible for automated cleanup — `review` always requires human approval
+
+## GitHub Issue Convention
+
+Title format: `type(scope): Short action-oriented summary`
+
+Types: `epic`, `story`, `enabler`, `bug`
+
+Required body sections:
+```markdown
+## Description
+## Acceptance Criteria
+- [ ]
+## Non-goals
+## Parent
+```
+
+Labels: type label + priority (`P0`–`P3`) + scope label (`scan`, `clean`, `doctor`, `tools`, `report`, `infra`, `schedule`)
+
+## Escalation Rules
+
+Escalate instead of guessing when:
+- Requirements are ambiguous
+- Multiple architectural paths are plausible
+- A change may have irreversible impact
+- Critical assumptions cannot be verified
+
+State: what is unclear / viable options / the blocked assumption.
+
+## Final Response Format
+
+After completing any item, include:
+1. What changed
+2. Files touched
+3. Validation performed
+4. Limitations / risks
+5. Recommended next steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,11 @@ dependencies = []
 [project.scripts]
 mac-care = "mac_care.cli:main"
 
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/mac_care/clean.py
+++ b/src/mac_care/clean.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from .git_safety import unsafe_repos
 from .model import Finding
+
+# Categories whose paths may contain git repos — always re-check before acting.
+_WORKSPACE_CATEGORIES = {"codex_workspaces"}
 
 
 def safe_clean(findings: list[Finding], dry_run: bool = True) -> list[str]:
@@ -8,8 +14,22 @@ def safe_clean(findings: list[Finding], dry_run: bool = True) -> list[str]:
     for finding in findings:
         if finding.risk != "auto_safe":
             continue
+
+        # Re-run git safety gate for workspace-adjacent categories even if
+        # scan already marked them auto_safe (belt-and-suspenders guard).
+        if finding.category in _WORKSPACE_CATEGORIES:
+            dirty = unsafe_repos(Path(finding.path))
+            if dirty:
+                actions.append(
+                    f"skipped {finding.category}: unsafe git repos detected at scan time — "
+                    f"{', '.join(str(r) for r in dirty[:2])}"
+                )
+                continue
+
         if dry_run:
             actions.append(f"would clean {finding.category}: {finding.path}")
         else:
-            actions.append(f"skipped execution for {finding.category}: deletion policies are not implemented yet")
+            actions.append(
+                f"skipped execution for {finding.category}: deletion policies are not implemented yet"
+            )
     return actions

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -4,7 +4,7 @@ import argparse
 
 from .clean import safe_clean
 from .config import Config
-from .doctor import check_tools
+from .doctor import check_tools, recommend_tools
 from .model import format_bytes
 from .report import write_reports
 from .scan import scan
@@ -17,7 +17,15 @@ def main() -> int:
 
     subparsers.add_parser("scan", help="Scan cleanup opportunities and write reports")
     subparsers.add_parser("doctor", help="Check developer tool health")
-    subparsers.add_parser("tools", help="Show required and optional tool status")
+
+    tools_parser = subparsers.add_parser("tools", help="OSS tool status and recommendations")
+    tools_parser.add_argument(
+        "action",
+        nargs="?",
+        default="status",
+        choices=["status", "recommend"],
+        help="status: show installed/missing tools (default). recommend: show install hints for missing tools.",
+    )
 
     clean_parser = subparsers.add_parser("clean", help="Run safe cleanup policy")
     clean_parser.add_argument("--safe", action="store_true", help="Only consider auto_safe findings")
@@ -32,6 +40,9 @@ def main() -> int:
         return 0
 
     if args.command == "tools":
+        if args.action == "recommend":
+            return _tools_recommend()
+        # default: status
         for status in check_tools(include_optional=True):
             print(f"{status.name}: {status.status} - {status.detail}")
         return 0
@@ -57,6 +68,27 @@ def main() -> int:
 
     parser.error("unknown command")
     return 2
+
+
+def _tools_recommend() -> int:
+    recs = recommend_tools()
+    if not recs:
+        print("All recommended OSS tools are already installed.")
+        return 0
+
+    # Group by function
+    groups: dict[str, list[dict]] = {}
+    for rec in recs:
+        groups.setdefault(rec["group"], []).append(rec)
+
+    print("Recommended OSS tools to install:\n")
+    for group, items in groups.items():
+        print(f"  {group}:")
+        for item in items:
+            print(f"    {item['name']:<14}  {item['desc']}")
+            print(f"    {'':14}  → {item['install']}")
+        print()
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/mac_care/doctor.py
+++ b/src/mac_care/doctor.py
@@ -29,7 +29,56 @@ OSS_OPTIONAL_TOOLS = [
     "mole",
     "cleardisk",
     "mas",
+    "pearcleaner",
 ]
+
+# Grouped recommendations shown by `mac-care tools recommend`.
+# Keys match entries in OSS_OPTIONAL_TOOLS where relevant.
+TOOL_RECOMMENDATIONS: dict[str, dict[str, str]] = {
+    # --- Disk analysis ---
+    "dua": {
+        "group": "Disk analysis",
+        "desc": "Fast parallel disk usage tree — primary backend for mac-care scan",
+        "install": "brew install dua-cli",
+    },
+    "dust": {
+        "group": "Disk analysis",
+        "desc": "Rust-based directory size tree, great for quick terminal overviews",
+        "install": "brew install dust",
+    },
+    "gdu": {
+        "group": "Disk analysis",
+        "desc": "Interactive Go disk usage browser (ncdu alternative)",
+        "install": "brew install gdu",
+    },
+    "ncdu": {
+        "group": "Disk analysis",
+        "desc": "Classic ncurses disk usage browser",
+        "install": "brew install ncdu",
+    },
+    # --- Package / app management ---
+    "mas": {
+        "group": "Package management",
+        "desc": "Mac App Store CLI — check for app updates from the terminal",
+        "install": "brew install mas",
+    },
+    "pearcleaner": {
+        "group": "App cleanup",
+        "desc": "Finds orphaned app support files left behind after app deletion",
+        "install": "brew install --cask pearcleaner",
+    },
+    # --- Network / SSH ---
+    "mole": {
+        "group": "Network",
+        "desc": "SSH tunnel manager — not used by mac-care scan but useful on a dev machine",
+        "install": "brew install mole",
+    },
+}
+
+
+@staticmethod
+def _tool_installed(name: str) -> bool:
+    return which(name) is not None
 
 
 def check_tools(include_optional: bool = True) -> list[ToolStatus]:
@@ -52,6 +101,19 @@ def check_tools(include_optional: bool = True) -> list[ToolStatus]:
             statuses.append(ToolStatus(name=name, status="available" if found else "optional_missing", detail=found or "optional integration not installed"))
 
     return statuses
+
+
+def recommend_tools() -> list[dict[str, str]]:
+    """Return recommendations for missing optional OSS tools, grouped by function.
+
+    Each entry is a dict with keys: name, group, desc, install, status.
+    Only tools that are NOT already installed are included.
+    """
+    missing = []
+    for name, info in TOOL_RECOMMENDATIONS.items():
+        if not which(name):
+            missing.append({"name": name, **info, "status": "not installed"})
+    return missing
 
 
 def _docker_status() -> ToolStatus:

--- a/src/mac_care/git_safety.py
+++ b/src/mac_care/git_safety.py
@@ -1,0 +1,74 @@
+"""
+git_safety.py — detect dirty or active git repos under a path.
+
+Used by scan.py and clean.py to protect live developer work before
+any cleanup action touches workspace directories.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def find_git_repos(root: Path, max_depth: int = 4) -> list[Path]:
+    """Return paths of git repo roots found under *root* up to *max_depth*."""
+    repos: list[Path] = []
+    if not root.exists():
+        return repos
+
+    def _walk(path: Path, depth: int) -> None:
+        if depth > max_depth:
+            return
+        git_dir = path / ".git"
+        if git_dir.exists():
+            repos.append(path)
+            return  # don't recurse into nested repos
+        try:
+            for child in path.iterdir():
+                if child.is_dir() and not child.is_symlink():
+                    _walk(child, depth + 1)
+        except PermissionError:
+            pass
+
+    _walk(root, 0)
+    return repos
+
+
+def is_dirty(repo_path: Path) -> bool:
+    """Return True if the repo has any uncommitted changes (staged, unstaged, or untracked)."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return bool(result.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        # If we can't check, treat as dirty to be safe.
+        return True
+
+
+def has_active_worktrees(repo_path: Path) -> bool:
+    """Return True if the repo has more than one worktree (i.e. active worktree checkouts)."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        # Each worktree entry starts with "worktree <path>"
+        count = sum(1 for line in result.stdout.splitlines() if line.startswith("worktree "))
+        return count > 1
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return True  # Treat as active if we can't check.
+
+
+def unsafe_repos(root: Path) -> list[Path]:
+    """Return list of repo paths under *root* that are dirty or have active worktrees."""
+    return [
+        repo
+        for repo in find_git_repos(root)
+        if is_dirty(repo) or has_active_worktrees(repo)
+    ]

--- a/src/mac_care/model.py
+++ b/src/mac_care/model.py
@@ -15,6 +15,7 @@ class Finding:
     size_bytes: int
     risk: Risk
     reason: str
+    source: str = "native"  # which tool produced this finding: native | brew | dua | docker | pearcleaner
 
 
 @dataclass(frozen=True)

--- a/src/mac_care/scan.py
+++ b/src/mac_care/scan.py
@@ -9,6 +9,7 @@ from .model import Finding, path_size
 from .tools.brew import brew_cleanup_findings
 from .tools.disk import size_of, top_subdirs_summary
 from .tools.docker_check import docker_findings
+from .tools.pearcleaner import pearcleaner_findings
 
 # Directories larger than this get a top-subdirs breakdown appended to reason.
 _BREAKDOWN_THRESHOLD_BYTES = 500 * 1024 * 1024  # 500 MB
@@ -22,6 +23,7 @@ def scan(config: Config) -> list[Finding]:
     findings.extend(_codex_workspace_review(config))
     findings.extend(brew_cleanup_findings())
     findings.extend(docker_findings())
+    findings.extend(pearcleaner_findings())
     return [item for item in findings if item.size_bytes > 0 or item.risk == "review"]
 
 

--- a/src/mac_care/scan.py
+++ b/src/mac_care/scan.py
@@ -7,6 +7,10 @@ from .config import Config
 from .git_safety import unsafe_repos
 from .model import Finding, path_size
 from .tools.brew import brew_cleanup_findings
+from .tools.disk import size_of, top_subdirs_summary
+
+# Directories larger than this get a top-subdirs breakdown appended to reason.
+_BREAKDOWN_THRESHOLD_BYTES = 500 * 1024 * 1024  # 500 MB
 
 
 def scan(config: Config) -> list[Finding]:
@@ -76,14 +80,29 @@ def _codex_workspace_review(config: Config) -> list[Finding]:
         reason = "old agent workspaces can be large; active work must be checked before deletion"
         risk = "review"
 
-    return [Finding("codex_workspaces", str(codex_docs), path_size(codex_docs), risk, reason)]  # type: ignore[arg-type]
+    total = size_of(codex_docs)
+    if total >= _BREAKDOWN_THRESHOLD_BYTES and risk != "protected":
+        summary = top_subdirs_summary(codex_docs)
+        if summary:
+            reason = f"{reason}; {summary}"
+
+    return [Finding("codex_workspaces", str(codex_docs), total, risk, reason)]  # type: ignore[arg-type]
 
 
 def _finding(category: str, path: Path, risk: str, reason: str, config: Config) -> Finding:
     resolved = path.expanduser()
     if _is_protected(resolved, config):
         risk = "protected"
-    return Finding(category, str(resolved), path_size(resolved), risk, reason)  # type: ignore[arg-type]
+
+    total = size_of(resolved)
+
+    # Enrich reason with top-subdirs breakdown for large directories
+    if total >= _BREAKDOWN_THRESHOLD_BYTES and risk != "protected":
+        summary = top_subdirs_summary(resolved)
+        if summary:
+            reason = f"{reason}; {summary}"
+
+    return Finding(category, str(resolved), total, risk, reason)  # type: ignore[arg-type]
 
 
 def _is_protected(path: Path, config: Config) -> bool:

--- a/src/mac_care/scan.py
+++ b/src/mac_care/scan.py
@@ -8,6 +8,7 @@ from .git_safety import unsafe_repos
 from .model import Finding, path_size
 from .tools.brew import brew_cleanup_findings
 from .tools.disk import size_of, top_subdirs_summary
+from .tools.docker_check import docker_findings
 
 # Directories larger than this get a top-subdirs breakdown appended to reason.
 _BREAKDOWN_THRESHOLD_BYTES = 500 * 1024 * 1024  # 500 MB
@@ -20,6 +21,7 @@ def scan(config: Config) -> list[Finding]:
     findings.extend(_downloads_review(config))
     findings.extend(_codex_workspace_review(config))
     findings.extend(brew_cleanup_findings())
+    findings.extend(docker_findings())
     return [item for item in findings if item.size_bytes > 0 or item.risk == "review"]
 
 

--- a/src/mac_care/scan.py
+++ b/src/mac_care/scan.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import time
 
 from .config import Config
+from .git_safety import unsafe_repos
 from .model import Finding, path_size
 
 
@@ -61,7 +62,18 @@ def _codex_workspace_review(config: Config) -> list[Finding]:
     codex_docs = Path.home() / "Documents/Codex"
     if not codex_docs.exists():
         return []
-    return [Finding("codex_workspaces", str(codex_docs), path_size(codex_docs), "review", "old agent workspaces can be large; active work must be checked before deletion")]
+
+    dirty = unsafe_repos(codex_docs)
+    if dirty:
+        repo_list = ", ".join(str(r) for r in dirty[:3])
+        suffix = f" and {len(dirty) - 3} more" if len(dirty) > 3 else ""
+        reason = f"active/dirty git repos detected — cannot auto-clean: {repo_list}{suffix}"
+        risk: str = "protected"
+    else:
+        reason = "old agent workspaces can be large; active work must be checked before deletion"
+        risk = "review"
+
+    return [Finding("codex_workspaces", str(codex_docs), path_size(codex_docs), risk, reason)]  # type: ignore[arg-type]
 
 
 def _finding(category: str, path: Path, risk: str, reason: str, config: Config) -> Finding:

--- a/src/mac_care/scan.py
+++ b/src/mac_care/scan.py
@@ -6,6 +6,7 @@ import time
 from .config import Config
 from .git_safety import unsafe_repos
 from .model import Finding, path_size
+from .tools.brew import brew_cleanup_findings
 
 
 def scan(config: Config) -> list[Finding]:
@@ -14,6 +15,7 @@ def scan(config: Config) -> list[Finding]:
     findings.extend(_developer_paths(config))
     findings.extend(_downloads_review(config))
     findings.extend(_codex_workspace_review(config))
+    findings.extend(brew_cleanup_findings())
     return [item for item in findings if item.size_bytes > 0 or item.risk == "review"]
 
 
@@ -34,7 +36,8 @@ def _developer_paths(config: Config) -> list[Finding]:
         ("xcode_derived_data", home / "Library/Developer/Xcode/DerivedData", "rebuildable Xcode artifacts"),
         ("xcode_archives", home / "Library/Developer/Xcode/Archives", "review archives before deleting"),
         ("android_gradle_cache", home / ".gradle/caches", "Gradle cache cleanup should be conservative"),
-        ("homebrew_cache", home / "Library/Caches/Homebrew", "Homebrew cache is rebuildable"),
+        # homebrew_cache removed: brew_cleanup_findings() in scan() provides
+        # richer, item-level findings directly from `brew cleanup --dry-run`
     ]
     findings: list[Finding] = []
     for category, path, reason in candidates:

--- a/src/mac_care/tools/brew.py
+++ b/src/mac_care/tools/brew.py
@@ -1,0 +1,91 @@
+"""
+tools/brew.py — Homebrew cleanup findings via `brew cleanup --dry-run`.
+
+Parses brew's own output to determine what it considers safe to remove.
+We trust brew's judgment: anything it would clean is tagged auto_safe.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from shutil import which
+
+from ..model import Finding
+
+# Matches: "Would remove: /some/path (42 files, 3.4MB)"
+#       or "Would remove: /some/path (3.4MB)"
+#       or "Would remove (broken link): /some/path"
+#       or "Would remove (empty directory): /some/path"
+_REMOVE_RE = re.compile(
+    r"^Would remove(?P<qualifier> \([^)]+\))?: (?P<path>[^\s(]+)"
+    r"(?:\s+\((?:[\d,]+ files?,\s*)?(?P<size>[0-9.]+\s*[KMGT]?B)\))?",
+)
+
+# Maps brew size suffixes → bytes multipliers
+_UNIT: dict[str, int] = {
+    "B": 1,
+    "KB": 1_000,
+    "MB": 1_000_000,
+    "GB": 1_000_000_000,
+    "TB": 1_000_000_000_000,
+}
+
+
+def _parse_size(raw: str | None) -> int:
+    """Convert a brew size string like '3.4MB' or '109.2MB' to bytes."""
+    if not raw:
+        return 0
+    raw = raw.strip().replace(",", "")
+    for suffix, mult in sorted(_UNIT.items(), key=lambda kv: -len(kv[0])):
+        if raw.endswith(suffix):
+            try:
+                return int(float(raw[: -len(suffix)]) * mult)
+            except ValueError:
+                return 0
+    return 0
+
+
+def brew_cleanup_findings() -> list[Finding]:
+    """Run ``brew cleanup --dry-run`` and return one Finding per removable item.
+
+    Returns an empty list (never raises) if brew is not installed or the
+    command fails for any reason.
+    """
+    if not which("brew"):
+        return []
+
+    env = {**os.environ, "HOMEBREW_NO_AUTO_UPDATE": "1"}
+    try:
+        result = subprocess.run(
+            ["brew", "cleanup", "--dry-run"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    findings: list[Finding] = []
+    for line in result.stdout.splitlines():
+        m = _REMOVE_RE.match(line.strip())
+        if not m:
+            continue
+        path = m.group("path")
+        size = _parse_size(m.group("size"))
+        qualifier = (m.group("qualifier") or "").strip(" ()")
+        reason = f"brew cleanup: safe to remove" + (f" ({qualifier})" if qualifier else "")
+        findings.append(
+            Finding(
+                category="brew_cache",
+                path=path,
+                size_bytes=size,
+                risk="auto_safe",
+                reason=reason,
+                source="brew",
+            )
+        )
+
+    return findings

--- a/src/mac_care/tools/disk.py
+++ b/src/mac_care/tools/disk.py
@@ -1,0 +1,167 @@
+"""
+tools/disk.py — disk usage analysis via dua (preferred) or macOS du (fallback).
+
+dua (https://github.com/Byron/dua-cli) is fast and parallel.
+macOS `du` is always available and used when dua is not installed.
+
+Public API
+----------
+size_of(path)           → int bytes  (total size of path)
+top_subdirs(path, n=5)  → list[(Path, int)]  (largest N immediate children)
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from shutil import which
+
+# Strip ANSI escape sequences from dua output
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# dua helpers
+# ---------------------------------------------------------------------------
+
+def _dua_available() -> bool:
+    return which("dua") is not None
+
+
+def _run_dua(path: Path) -> list[tuple[Path, int]]:
+    """Run ``dua aggregate -f bytes <children...>`` and return (child, bytes) pairs.
+
+    We expand children in Python (not shell) to avoid glob quoting issues in
+    subprocess. Skips the "total" summary line. Returns [] on any failure.
+    """
+    try:
+        children = [str(c) for c in path.iterdir()]
+    except (PermissionError, OSError):
+        return []
+    if not children:
+        return []
+
+    try:
+        result = subprocess.run(
+            ["dua", "aggregate", "-f", "bytes", "--no-sort", *children],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    entries: list[tuple[Path, int]] = []
+    for raw_line in result.stdout.splitlines():
+        line = _strip_ansi(raw_line).strip()
+        if not line or line.endswith("total"):
+            continue
+        # Format: "<bytes> b <path>"
+        parts = line.split(None, 2)  # ["27406336", "b", "/path/to/dir"]
+        if len(parts) != 3 or parts[1] != "b":
+            continue
+        try:
+            size = int(parts[0])
+            child = Path(parts[2])
+            entries.append((child, size))
+        except (ValueError, IndexError):
+            continue
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# du fallback helpers
+# ---------------------------------------------------------------------------
+
+def _run_du(path: Path) -> list[tuple[Path, int]]:
+    """Run ``du -d 1 -k <path>`` (macOS built-in) and return (child, bytes) pairs.
+
+    -d 1 limits to immediate children. -k gives kilobytes.
+    Returns [] on any failure.
+    """
+    try:
+        result = subprocess.run(
+            ["du", "-d", "1", "-k", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    entries: list[tuple[Path, int]] = []
+    for line in result.stdout.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        try:
+            size_bytes = int(parts[0]) * 1024  # kilobytes → bytes
+            child = Path(parts[1])
+            # Skip the path itself (du -d 1 includes a summary line for the root)
+            if child == path:
+                continue
+            entries.append((child, size_bytes))
+        except (ValueError, IndexError):
+            continue
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def top_subdirs(path: Path, n: int = 5) -> list[tuple[Path, int]]:
+    """Return the *n* largest immediate children of *path*, sorted descending.
+
+    Uses dua if available, falls back to macOS du. Returns [] if path doesn't
+    exist or all backends fail.
+    """
+    if not path.exists():
+        return []
+
+    entries = _run_dua(path) if _dua_available() else _run_du(path)
+    entries.sort(key=lambda e: e[1], reverse=True)
+    return entries[:n]
+
+
+def size_of(path: Path) -> int:
+    """Return total disk usage of *path* in bytes.
+
+    Uses dua aggregate total if available, otherwise sums du -d 1 output.
+    Falls back to Python rglob if both fail (imported lazily to avoid circular).
+    """
+    if not path.exists():
+        return 0
+
+    if _dua_available():
+        entries = _run_dua(path)
+        if entries:
+            return sum(size for _, size in entries)
+
+    # du fallback — sum all child entries (root summary not included after filtering)
+    entries = _run_du(path)
+    if entries:
+        return sum(size for _, size in entries)
+
+    # Last resort: Python rglob (slow but always works)
+    from ..model import path_size
+    return path_size(path)
+
+
+def top_subdirs_summary(path: Path, n: int = 5) -> str:
+    """Return a human-readable summary of the top N subdirs, e.g. for Finding.reason.
+
+    Example: "largest: Google (1.3 GB), ms-playwright (1.1 GB), SiriTTS (499 MB)"
+    Returns empty string if no data available.
+    """
+    from ..model import format_bytes
+
+    entries = top_subdirs(path, n)
+    if not entries:
+        return ""
+    parts = [f"{child.name} ({format_bytes(size)})" for child, size in entries]
+    return "largest: " + ", ".join(parts)

--- a/src/mac_care/tools/docker_check.py
+++ b/src/mac_care/tools/docker_check.py
@@ -1,0 +1,129 @@
+"""
+tools/docker_check.py — Docker disk usage findings via `docker system df`.
+
+Reports reclaimable space per category (images, containers, volumes, build
+cache) as review-risk findings. Never auto-cleans anything — Docker cleanup
+requires explicit user action (docker system prune, etc.).
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from shutil import which
+
+from ..model import Finding
+
+# Maps docker Type → (mac-care category, cleanup hint)
+_TYPE_META: dict[str, tuple[str, str]] = {
+    "Images":      ("docker_images",       "remove with: docker image prune [-a]"),
+    "Containers":  ("docker_containers",   "remove with: docker container prune"),
+    "Local Volumes": ("docker_volumes",    "remove with: docker volume prune"),
+    "Build Cache": ("docker_build_cache",  "remove with: docker builder prune"),
+}
+
+# Parses size strings like "9.789GB", "197.6MB", "1.227MB", "0B"
+_SIZE_RE = re.compile(r"^(?P<value>[0-9.]+)\s*(?P<unit>[KMGT]?B)$", re.IGNORECASE)
+
+_UNIT_BYTES: dict[str, int] = {
+    "B":  1,
+    "KB": 1_000,
+    "MB": 1_000_000,
+    "GB": 1_000_000_000,
+    "TB": 1_000_000_000_000,
+}
+
+
+def _parse_docker_size(raw: str) -> int:
+    """Convert docker size string like '9.789GB' or '197.6MB (13%)' to bytes."""
+    # Strip parenthetical percentage if present: "9.789GB (49%)" → "9.789GB"
+    raw = raw.split("(")[0].strip()
+    m = _SIZE_RE.match(raw)
+    if not m:
+        return 0
+    try:
+        value = float(m.group("value"))
+        unit = m.group("unit").upper()
+        return int(value * _UNIT_BYTES.get(unit, 1))
+    except (ValueError, KeyError):
+        return 0
+
+
+def _docker_available() -> bool:
+    return which("docker") is not None
+
+
+def _daemon_reachable() -> bool:
+    """Return True if the Docker daemon is running and reachable."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=8,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def docker_findings() -> list[Finding]:
+    """Run ``docker system df --format '{{json .}}'`` and return one Finding
+    per category that has reclaimable space > 0.
+
+    All findings are risk="review" — Docker cleanup is always user-initiated.
+    Returns [] (never raises) if Docker is not installed or daemon is offline.
+    """
+    if not _docker_available():
+        return []
+    if not _daemon_reachable():
+        return []
+
+    try:
+        result = subprocess.run(
+            ["docker", "system", "df", "--format", "{{json .}}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    findings: list[Finding] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        docker_type = row.get("Type", "")
+        category, hint = _TYPE_META.get(docker_type, (None, None))
+        if category is None:
+            continue
+
+        reclaimable_bytes = _parse_docker_size(row.get("Reclaimable", "0B"))
+        if reclaimable_bytes == 0:
+            continue
+
+        total_bytes = _parse_docker_size(row.get("Size", "0B"))
+        total_count = row.get("TotalCount", "?")
+        active = row.get("Active", "?")
+
+        reason = (
+            f"{total_count} total, {active} active; "
+            f"reclaimable: {row.get('Reclaimable', '?')}; {hint}"
+        )
+
+        findings.append(Finding(
+            category=category,
+            path="docker://" + docker_type.lower().replace(" ", "_"),
+            size_bytes=reclaimable_bytes,
+            risk="review",
+            reason=reason,
+            source="docker",
+        ))
+
+    return findings

--- a/src/mac_care/tools/pearcleaner.py
+++ b/src/mac_care/tools/pearcleaner.py
@@ -1,0 +1,96 @@
+"""
+tools/pearcleaner.py — orphaned app support file findings via Pearcleaner CLI.
+
+Pearcleaner (https://github.com/alienator88/Pearcleaner) finds leftover files
+from deleted apps: support directories, preferences, caches, logs that remain
+after dragging an app to the trash.
+
+CLI: `pearcleaner list-orphaned`
+Output: one absolute path per line, ending with "Found N orphaned files."
+
+All findings are risk="review" — orphaned file cleanup always requires human
+confirmation. Never auto-clean anything from this source.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from shutil import which
+
+from ..model import Finding, path_size
+
+# Known paths where pearcleaner binary may live even if not on PATH
+_APP_BINARY_PATHS = [
+    "/Applications/Pearcleaner.app/Contents/MacOS/Pearcleaner",
+    "/opt/homebrew/bin/pearcleaner",  # brew --cask symlink target
+]
+
+
+def _pearcleaner_bin() -> str | None:
+    """Return path to the pearcleaner binary, or None if not found."""
+    found = which("pearcleaner")
+    if found:
+        return found
+    for candidate in _APP_BINARY_PATHS:
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def pearcleaner_findings() -> list[Finding]:
+    """Run ``pearcleaner list-orphaned`` and return one Finding per orphaned path.
+
+    Each finding is risk="review" — the user must confirm before any deletion.
+    Returns [] (never raises) if Pearcleaner is not installed or the command fails.
+    """
+    binary = _pearcleaner_bin()
+    if not binary:
+        return []
+
+    try:
+        result = subprocess.run(
+            [binary, "list-orphaned"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    findings: list[Finding] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # Skip the summary line: "Found N orphaned files."
+        if line.startswith("Found ") and line.endswith("orphaned files."):
+            continue
+
+        path = Path(line)
+        # Determine a human-readable app name from the path for the reason field
+        app_name = _guess_app_name(path)
+        reason = f"orphaned app support files" + (f" for {app_name}" if app_name else "")
+
+        findings.append(Finding(
+            category="orphaned_app_files",
+            path=str(path),
+            size_bytes=path_size(path),
+            risk="review",
+            reason=reason,
+            source="pearcleaner",
+        ))
+
+    return findings
+
+
+def _guess_app_name(path: Path) -> str:
+    """Extract a readable app identifier from a support file path.
+
+    Examples:
+      ~/Library/Application Support/com.example.App  → com.example.App
+      ~/Library/Caches/com.example.App               → com.example.App
+      ~/Library/Preferences/com.example.App.plist    → com.example.App
+    """
+    name = path.stem if path.is_file() else path.name
+    # Strip leading dots from hidden dirs
+    return name.lstrip(".")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mac_care.doctor import recommend_tools, TOOL_RECOMMENDATIONS
+
+
+def test_recommend_tools_returns_missing_only() -> None:
+    """Only tools not on PATH should appear in recommendations."""
+    with patch("mac_care.doctor.which", return_value=None):
+        recs = recommend_tools()
+
+    names = {r["name"] for r in recs}
+    assert names == set(TOOL_RECOMMENDATIONS.keys())
+
+
+def test_recommend_tools_excludes_installed() -> None:
+    """A tool that is installed should not appear in recommendations."""
+    def fake_which(name: str) -> str | None:
+        return f"/usr/local/bin/{name}" if name == "dua" else None
+
+    with patch("mac_care.doctor.which", side_effect=fake_which):
+        recs = recommend_tools()
+
+    names = {r["name"] for r in recs}
+    assert "dua" not in names
+
+
+def test_recommend_tools_empty_when_all_installed() -> None:
+    with patch("mac_care.doctor.which", return_value="/usr/local/bin/tool"):
+        recs = recommend_tools()
+    assert recs == []
+
+
+def test_recommend_tools_has_required_keys() -> None:
+    with patch("mac_care.doctor.which", return_value=None):
+        recs = recommend_tools()
+    for rec in recs:
+        assert "name" in rec
+        assert "group" in rec
+        assert "desc" in rec
+        assert "install" in rec
+        assert "status" in rec
+
+
+def test_recommend_tools_install_commands_start_with_brew() -> None:
+    with patch("mac_care.doctor.which", return_value=None):
+        recs = recommend_tools()
+    for rec in recs:
+        assert rec["install"].startswith("brew "), f"{rec['name']} install hint should start with 'brew'"

--- a/tests/test_git_safety.py
+++ b/tests/test_git_safety.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mac_care.git_safety import find_git_repos, has_active_worktrees, is_dirty, unsafe_repos
+
+
+# ---------------------------------------------------------------------------
+# find_git_repos
+# ---------------------------------------------------------------------------
+
+def test_find_git_repos_empty_dir(tmp_path: Path) -> None:
+    assert find_git_repos(tmp_path) == []
+
+
+def test_find_git_repos_finds_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "myproject"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    result = find_git_repos(tmp_path)
+    assert result == [repo]
+
+
+def test_find_git_repos_does_not_recurse_into_nested(tmp_path: Path) -> None:
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    (outer / ".git").mkdir()
+    inner = outer / "inner"
+    inner.mkdir()
+    (inner / ".git").mkdir()  # nested repo — should not appear separately
+    result = find_git_repos(tmp_path)
+    assert result == [outer]
+
+
+def test_find_git_repos_respects_max_depth(tmp_path: Path) -> None:
+    deep = tmp_path / "a" / "b" / "c" / "d" / "e"
+    deep.mkdir(parents=True)
+    (deep / ".git").mkdir()
+    # max_depth=2 should not reach depth 5
+    result = find_git_repos(tmp_path, max_depth=2)
+    assert result == []
+
+
+def test_find_git_repos_nonexistent_root() -> None:
+    assert find_git_repos(Path("/nonexistent/path/xyz")) == []
+
+
+# ---------------------------------------------------------------------------
+# is_dirty
+# ---------------------------------------------------------------------------
+
+def test_is_dirty_returns_true_when_output(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.stdout = " M src/foo.py\n"
+    with patch("subprocess.run", return_value=mock_result):
+        assert is_dirty(tmp_path) is True
+
+
+def test_is_dirty_returns_false_when_clean(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    with patch("subprocess.run", return_value=mock_result):
+        assert is_dirty(tmp_path) is False
+
+
+def test_is_dirty_treats_timeout_as_dirty(tmp_path: Path) -> None:
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="git", timeout=10)):
+        assert is_dirty(tmp_path) is True
+
+
+def test_is_dirty_treats_missing_git_as_dirty(tmp_path: Path) -> None:
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        assert is_dirty(tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# has_active_worktrees
+# ---------------------------------------------------------------------------
+
+def test_has_active_worktrees_single(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.stdout = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main\n"
+    with patch("subprocess.run", return_value=mock_result):
+        assert has_active_worktrees(tmp_path) is False
+
+
+def test_has_active_worktrees_multiple(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.stdout = (
+        "worktree /path/to/repo\nHEAD abc\nbranch refs/heads/main\n\n"
+        "worktree /path/to/worktree\nHEAD def\nbranch refs/heads/feature\n"
+    )
+    with patch("subprocess.run", return_value=mock_result):
+        assert has_active_worktrees(tmp_path) is True
+
+
+def test_has_active_worktrees_timeout_treated_as_active(tmp_path: Path) -> None:
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="git", timeout=10)):
+        assert has_active_worktrees(tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# unsafe_repos (integration of the above)
+# ---------------------------------------------------------------------------
+
+def test_unsafe_repos_empty_when_no_repos(tmp_path: Path) -> None:
+    assert unsafe_repos(tmp_path) == []
+
+
+def test_unsafe_repos_includes_dirty_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "project"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    dirty_result = MagicMock()
+    dirty_result.stdout = " M file.py\n"
+
+    clean_worktree = MagicMock()
+    clean_worktree.stdout = "worktree /path\nHEAD abc\n"
+
+    with patch("subprocess.run", side_effect=[dirty_result, clean_worktree]):
+        result = unsafe_repos(tmp_path)
+    assert result == [repo]
+
+
+def test_unsafe_repos_excludes_clean_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "project"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    clean_status = MagicMock()
+    clean_status.stdout = ""
+
+    single_worktree = MagicMock()
+    single_worktree.stdout = "worktree /path\nHEAD abc\nbranch refs/heads/main\n"
+
+    with patch("subprocess.run", side_effect=[clean_status, single_worktree]):
+        result = unsafe_repos(tmp_path)
+    assert result == []

--- a/tests/tools/test_brew.py
+++ b/tests/tools/test_brew.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mac_care.tools.brew import _parse_size, brew_cleanup_findings
+
+
+# ---------------------------------------------------------------------------
+# _parse_size
+# ---------------------------------------------------------------------------
+
+def test_parse_size_megabytes() -> None:
+    assert _parse_size("3.4MB") == 3_400_000
+
+
+def test_parse_size_gigabytes() -> None:
+    assert _parse_size("1.5GB") == 1_500_000_000
+
+
+def test_parse_size_kilobytes() -> None:
+    assert _parse_size("64B") == 64
+
+
+def test_parse_size_with_commas() -> None:
+    # brew sometimes formats as "1,641 files, 34.2MB"
+    assert _parse_size("34.2MB") == 34_200_000
+
+
+def test_parse_size_none() -> None:
+    assert _parse_size(None) == 0
+
+
+def test_parse_size_empty() -> None:
+    assert _parse_size("") == 0
+
+
+# ---------------------------------------------------------------------------
+# brew_cleanup_findings — happy path
+# ---------------------------------------------------------------------------
+
+SAMPLE_OUTPUT = """\
+Warning: Skipping ffmpeg: most recent version 8.1 not installed
+Would remove: /opt/homebrew/Cellar/xz/5.8.2 (96 files, 2.7MB)
+Would remove: /Users/user/Library/Logs/Homebrew/pyenv (64B)
+Would remove (broken link): /opt/homebrew/bin/github
+Would remove (empty directory): /opt/homebrew/share/google-cloud-sdk/.install/.download
+==> This operation would free approximately 109.2MB of disk space.
+"""
+
+
+def _mock_run(stdout: str):
+    result = MagicMock()
+    result.stdout = stdout
+    result.returncode = 0
+    return result
+
+
+def test_brew_cleanup_findings_parses_items() -> None:
+    with patch("mac_care.tools.brew.which", return_value="/opt/homebrew/bin/brew"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)):
+        findings = brew_cleanup_findings()
+
+    assert len(findings) == 4  # 4 "Would remove" lines; summary line ignored
+    paths = {f.path for f in findings}
+    assert "/opt/homebrew/Cellar/xz/5.8.2" in paths
+    assert "/Users/user/Library/Logs/Homebrew/pyenv" in paths
+    assert "/opt/homebrew/bin/github" in paths
+
+
+def test_brew_cleanup_findings_sizes() -> None:
+    with patch("mac_care.tools.brew.which", return_value="/opt/homebrew/bin/brew"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)):
+        findings = brew_cleanup_findings()
+
+    sizes = {f.path: f.size_bytes for f in findings}
+    assert sizes["/opt/homebrew/Cellar/xz/5.8.2"] == 2_700_000
+    assert sizes["/Users/user/Library/Logs/Homebrew/pyenv"] == 64
+    assert sizes["/opt/homebrew/bin/github"] == 0  # broken link — no size
+
+
+def test_brew_cleanup_findings_all_auto_safe() -> None:
+    with patch("mac_care.tools.brew.which", return_value="/opt/homebrew/bin/brew"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)):
+        findings = brew_cleanup_findings()
+
+    assert all(f.risk == "auto_safe" for f in findings)
+
+
+def test_brew_cleanup_findings_source_is_brew() -> None:
+    with patch("mac_care.tools.brew.which", return_value="/opt/homebrew/bin/brew"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)):
+        findings = brew_cleanup_findings()
+
+    assert all(f.source == "brew" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# brew_cleanup_findings — degradation
+# ---------------------------------------------------------------------------
+
+def test_brew_cleanup_findings_empty_when_brew_missing() -> None:
+    with patch("mac_care.tools.brew.which", return_value=None):
+        findings = brew_cleanup_findings()
+    assert findings == []
+
+
+def test_brew_cleanup_findings_empty_on_timeout() -> None:
+    import subprocess
+    with patch("mac_care.tools.brew.which", return_value="/opt/homebrew/bin/brew"), \
+         patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="brew", timeout=60)):
+        findings = brew_cleanup_findings()
+    assert findings == []
+
+
+def test_brew_cleanup_findings_empty_on_oserror() -> None:
+    with patch("mac_care.tools.brew.which", return_value="/opt/homebrew/bin/brew"), \
+         patch("subprocess.run", side_effect=OSError("something went wrong")):
+        findings = brew_cleanup_findings()
+    assert findings == []
+
+
+def test_brew_cleanup_findings_empty_output() -> None:
+    with patch("mac_care.tools.brew.which", return_value="/opt/homebrew/bin/brew"), \
+         patch("subprocess.run", return_value=_mock_run("")):
+        findings = brew_cleanup_findings()
+    assert findings == []

--- a/tests/tools/test_disk.py
+++ b/tests/tools/test_disk.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mac_care.tools.disk import size_of, top_subdirs, top_subdirs_summary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _dua_output(*entries: tuple[str, int], include_total: bool = True) -> str:
+    """Build mock dua aggregate -f bytes output with ANSI codes."""
+    lines = []
+    total = 0
+    for path, size in entries:
+        lines.append(f"\x1b[32m{size:>12} b\x1b[39m \x1b[36m{path}\x1b[39m")
+        total += size
+    if include_total:
+        lines.append(f"\x1b[32m{total:>12} b\x1b[39m total")
+    return "\n".join(lines) + "\n"
+
+
+def _du_output(root: str, *entries: tuple[str, int]) -> str:
+    """Build mock du -d 1 -k output (kilobytes, tab-separated)."""
+    lines = []
+    for path, size_bytes in entries:
+        kb = size_bytes // 1024
+        lines.append(f"{kb}\t{path}")
+    # du also includes the root itself
+    total_kb = sum(size_bytes // 1024 for _, size_bytes in entries)
+    lines.append(f"{total_kb}\t{root}")
+    return "\n".join(lines) + "\n"
+
+
+def _mock_run(stdout: str) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    result.returncode = 0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# top_subdirs — dua path
+# ---------------------------------------------------------------------------
+
+def test_top_subdirs_dua_returns_sorted_entries(tmp_path: Path) -> None:
+    # Create real children so path.iterdir() has something to return
+    for name in ("small", "large", "medium"):
+        (tmp_path / name).mkdir()
+    output = _dua_output(
+        (str(tmp_path / "small"), 1_000_000),
+        (str(tmp_path / "large"), 5_000_000),
+        (str(tmp_path / "medium"), 2_000_000),
+    )
+    with patch("mac_care.tools.disk._dua_available", return_value=True), \
+         patch("subprocess.run", return_value=_mock_run(output)):
+        result = top_subdirs(tmp_path, n=3)
+
+    assert len(result) == 3
+    assert result[0] == (tmp_path / "large", 5_000_000)
+    assert result[1] == (tmp_path / "medium", 2_000_000)
+    assert result[2] == (tmp_path / "small", 1_000_000)
+
+
+def test_top_subdirs_dua_respects_n(tmp_path: Path) -> None:
+    for name in ("a", "b", "c"):
+        (tmp_path / name).mkdir()
+    output = _dua_output(
+        (str(tmp_path / "a"), 3_000_000),
+        (str(tmp_path / "b"), 2_000_000),
+        (str(tmp_path / "c"), 1_000_000),
+    )
+    with patch("mac_care.tools.disk._dua_available", return_value=True), \
+         patch("subprocess.run", return_value=_mock_run(output)):
+        result = top_subdirs(tmp_path, n=2)
+
+    assert len(result) == 2
+    assert result[0][0].name == "a"
+
+
+def test_top_subdirs_dua_skips_total_line(tmp_path: Path) -> None:
+    (tmp_path / "only").mkdir()
+    output = _dua_output((str(tmp_path / "only"), 1_000_000), include_total=True)
+    with patch("mac_care.tools.disk._dua_available", return_value=True), \
+         patch("subprocess.run", return_value=_mock_run(output)):
+        result = top_subdirs(tmp_path)
+
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# top_subdirs — du fallback
+# ---------------------------------------------------------------------------
+
+def test_top_subdirs_du_fallback(tmp_path: Path) -> None:
+    output = _du_output(
+        str(tmp_path),
+        (str(tmp_path / "big"), 10 * 1024 * 1024),
+        (str(tmp_path / "tiny"), 512 * 1024),
+    )
+    with patch("mac_care.tools.disk._dua_available", return_value=False), \
+         patch("subprocess.run", return_value=_mock_run(output)):
+        result = top_subdirs(tmp_path)
+
+    assert len(result) == 2
+    assert result[0][0].name == "big"
+    assert result[0][1] == 10 * 1024 * 1024
+
+
+def test_top_subdirs_empty_for_nonexistent_path() -> None:
+    result = top_subdirs(Path("/nonexistent/path/xyz"))
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# size_of
+# ---------------------------------------------------------------------------
+
+def test_size_of_sums_dua_entries(tmp_path: Path) -> None:
+    for name in ("a", "b"):
+        (tmp_path / name).mkdir()
+    output = _dua_output(
+        (str(tmp_path / "a"), 1_000_000),
+        (str(tmp_path / "b"), 2_000_000),
+    )
+    with patch("mac_care.tools.disk._dua_available", return_value=True), \
+         patch("subprocess.run", return_value=_mock_run(output)):
+        total = size_of(tmp_path)
+
+    assert total == 3_000_000
+
+
+def test_size_of_zero_for_nonexistent() -> None:
+    assert size_of(Path("/nonexistent/xyz")) == 0
+
+
+def test_size_of_falls_back_to_du_when_dua_unavailable(tmp_path: Path) -> None:
+    output = _du_output(
+        str(tmp_path),
+        (str(tmp_path / "x"), 4 * 1024 * 1024),
+    )
+    with patch("mac_care.tools.disk._dua_available", return_value=False), \
+         patch("subprocess.run", return_value=_mock_run(output)):
+        total = size_of(tmp_path)
+
+    assert total == 4 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# top_subdirs_summary
+# ---------------------------------------------------------------------------
+
+def test_top_subdirs_summary_format(tmp_path: Path) -> None:
+    for name in ("ProjectA", "ProjectB"):
+        (tmp_path / name).mkdir()
+    output = _dua_output(
+        (str(tmp_path / "ProjectA"), 4_300_000_000),
+        (str(tmp_path / "ProjectB"), 1_100_000_000),
+    )
+    with patch("mac_care.tools.disk._dua_available", return_value=True), \
+         patch("subprocess.run", return_value=_mock_run(output)):
+        summary = top_subdirs_summary(tmp_path)
+
+    assert summary.startswith("largest:")
+    assert "ProjectA" in summary
+    assert "ProjectB" in summary
+
+
+def test_top_subdirs_summary_empty_for_nonexistent() -> None:
+    assert top_subdirs_summary(Path("/nonexistent/xyz")) == ""

--- a/tests/tools/test_docker.py
+++ b/tests/tools/test_docker.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from mac_care.tools.docker_check import _parse_docker_size, docker_findings
+
+
+# ---------------------------------------------------------------------------
+# _parse_docker_size
+# ---------------------------------------------------------------------------
+
+def test_parse_gb() -> None:
+    assert _parse_docker_size("9.789GB") == 9_789_000_000
+
+
+def test_parse_mb() -> None:
+    assert _parse_docker_size("197.6MB") == 197_600_000
+
+
+def test_parse_with_percentage() -> None:
+    # "9.789GB (49%)" — docker includes reclaimable percentage inline
+    assert _parse_docker_size("9.789GB (49%)") == 9_789_000_000
+
+
+def test_parse_zero() -> None:
+    assert _parse_docker_size("0B") == 0
+
+
+def test_parse_empty() -> None:
+    assert _parse_docker_size("") == 0
+
+
+def test_parse_kb() -> None:
+    assert _parse_docker_size("1.227MB") == 1_227_000
+
+
+# ---------------------------------------------------------------------------
+# docker_findings — happy path
+# ---------------------------------------------------------------------------
+
+SAMPLE_DF = [
+    {"Active": "10", "Reclaimable": "9.789GB (49%)", "Size": "19.7GB",  "TotalCount": "52", "Type": "Images"},
+    {"Active": "5",  "Reclaimable": "1.227MB (2%)",  "Size": "47.05MB", "TotalCount": "11", "Type": "Containers"},
+    {"Active": "5",  "Reclaimable": "197.6MB (13%)", "Size": "1.486GB", "TotalCount": "10", "Type": "Local Volumes"},
+    {"Active": "0",  "Reclaimable": "4.982GB",        "Size": "5.098GB", "TotalCount": "91", "Type": "Build Cache"},
+]
+
+
+def _mock_df_run() -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "\n".join(json.dumps(row) for row in SAMPLE_DF) + "\n"
+    return result
+
+
+def _mock_info_run() -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = ""
+    return result
+
+
+def test_docker_findings_returns_four_categories() -> None:
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", return_value=_mock_df_run()):
+        findings = docker_findings()
+
+    assert len(findings) == 4
+    categories = {f.category for f in findings}
+    assert categories == {"docker_images", "docker_containers", "docker_volumes", "docker_build_cache"}
+
+
+def test_docker_findings_all_review_risk() -> None:
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", return_value=_mock_df_run()):
+        findings = docker_findings()
+
+    assert all(f.risk == "review" for f in findings)
+
+
+def test_docker_findings_all_source_docker() -> None:
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", return_value=_mock_df_run()):
+        findings = docker_findings()
+
+    assert all(f.source == "docker" for f in findings)
+
+
+def test_docker_findings_sizes_are_reclaimable() -> None:
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", return_value=_mock_df_run()):
+        findings = docker_findings()
+
+    by_cat = {f.category: f.size_bytes for f in findings}
+    assert by_cat["docker_images"] == 9_789_000_000
+    assert by_cat["docker_build_cache"] == 4_982_000_000
+
+
+def test_docker_findings_reason_includes_hint() -> None:
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", return_value=_mock_df_run()):
+        findings = docker_findings()
+
+    images = next(f for f in findings if f.category == "docker_images")
+    assert "docker image prune" in images.reason
+
+
+def test_docker_findings_skips_zero_reclaimable() -> None:
+    rows = [{"Active": "5", "Reclaimable": "0B", "Size": "10GB", "TotalCount": "5", "Type": "Images"}]
+    result = MagicMock()
+    result.stdout = json.dumps(rows[0]) + "\n"
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", return_value=result):
+        findings = docker_findings()
+
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# docker_findings — degradation
+# ---------------------------------------------------------------------------
+
+def test_docker_findings_empty_when_not_installed() -> None:
+    with patch("mac_care.tools.docker_check._docker_available", return_value=False):
+        assert docker_findings() == []
+
+
+def test_docker_findings_empty_when_daemon_offline() -> None:
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=False):
+        assert docker_findings() == []
+
+
+def test_docker_findings_empty_on_timeout() -> None:
+    import subprocess
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30)):
+        assert docker_findings() == []
+
+
+def test_docker_findings_empty_on_bad_json() -> None:
+    result = MagicMock()
+    result.stdout = "not json at all\n"
+    with patch("mac_care.tools.docker_check._docker_available", return_value=True), \
+         patch("mac_care.tools.docker_check._daemon_reachable", return_value=True), \
+         patch("subprocess.run", return_value=result):
+        assert docker_findings() == []

--- a/tests/tools/test_pearcleaner.py
+++ b/tests/tools/test_pearcleaner.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mac_care.tools.pearcleaner import _guess_app_name, pearcleaner_findings
+
+
+# ---------------------------------------------------------------------------
+# _guess_app_name
+# ---------------------------------------------------------------------------
+
+def test_guess_app_name_bundle_id_dir(tmp_path: Path) -> None:
+    path = tmp_path / "com.example.MyApp"
+    path.mkdir()
+    assert _guess_app_name(path) == "com.example.MyApp"
+
+
+def test_guess_app_name_plist_file(tmp_path: Path) -> None:
+    path = tmp_path / "com.example.MyApp.plist"
+    path.touch()
+    assert _guess_app_name(path) == "com.example.MyApp"
+
+
+def test_guess_app_name_strips_leading_dot(tmp_path: Path) -> None:
+    path = tmp_path / ".hidden-app-support"
+    path.mkdir()
+    assert _guess_app_name(path) == "hidden-app-support"
+
+
+# ---------------------------------------------------------------------------
+# pearcleaner_findings — happy path
+# ---------------------------------------------------------------------------
+
+SAMPLE_OUTPUT = """\
+/Users/user/Library/Application Support/com.example.DeletedApp
+/Users/user/Library/Caches/com.example.DeletedApp
+/Users/user/Library/Preferences/com.example.DeletedApp.plist
+
+Found 3 orphaned files.
+"""
+
+
+def _mock_run(stdout: str, returncode: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    result.returncode = returncode
+    return result
+
+
+def test_pearcleaner_findings_parses_paths() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)), \
+         patch("mac_care.tools.pearcleaner.path_size", return_value=1024):
+        findings = pearcleaner_findings()
+
+    assert len(findings) == 3
+    paths = {f.path for f in findings}
+    assert "/Users/user/Library/Application Support/com.example.DeletedApp" in paths
+    assert "/Users/user/Library/Caches/com.example.DeletedApp" in paths
+    assert "/Users/user/Library/Preferences/com.example.DeletedApp.plist" in paths
+
+
+def test_pearcleaner_findings_skips_summary_line() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)), \
+         patch("mac_care.tools.pearcleaner.path_size", return_value=0):
+        findings = pearcleaner_findings()
+
+    # Summary line "Found 3 orphaned files." must not become a Finding
+    assert all("Found" not in f.path for f in findings)
+
+
+def test_pearcleaner_findings_all_review_risk() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)), \
+         patch("mac_care.tools.pearcleaner.path_size", return_value=0):
+        findings = pearcleaner_findings()
+
+    assert all(f.risk == "review" for f in findings)
+
+
+def test_pearcleaner_findings_source_is_pearcleaner() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)), \
+         patch("mac_care.tools.pearcleaner.path_size", return_value=0):
+        findings = pearcleaner_findings()
+
+    assert all(f.source == "pearcleaner" for f in findings)
+
+
+def test_pearcleaner_findings_reason_contains_app_name() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", return_value=_mock_run(SAMPLE_OUTPUT)), \
+         patch("mac_care.tools.pearcleaner.path_size", return_value=0):
+        findings = pearcleaner_findings()
+
+    reasons = {f.reason for f in findings}
+    assert any("com.example.DeletedApp" in r for r in reasons)
+
+
+def test_pearcleaner_findings_empty_output() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", return_value=_mock_run("\nFound 0 orphaned files.\n")), \
+         patch("mac_care.tools.pearcleaner.path_size", return_value=0):
+        findings = pearcleaner_findings()
+
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# pearcleaner_findings — degradation
+# ---------------------------------------------------------------------------
+
+def test_pearcleaner_findings_empty_when_not_installed() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value=None):
+        assert pearcleaner_findings() == []
+
+
+def test_pearcleaner_findings_empty_on_timeout() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="pearcleaner", timeout=60)):
+        assert pearcleaner_findings() == []
+
+
+def test_pearcleaner_findings_empty_on_oserror() -> None:
+    with patch("mac_care.tools.pearcleaner._pearcleaner_bin", return_value="/usr/local/bin/pearcleaner"), \
+         patch("subprocess.run", side_effect=OSError("launch failed")):
+        assert pearcleaner_findings() == []


### PR DESCRIPTION
## What
First real PR for mac-care — moves from bare scaffold to a working local macOS maintenance CLI with OSS integrations, git safety, and project infrastructure.

## Why
Closes the initial bootstrap sprint. Establishes the patterns all future work will follow.

## Changes

**Infrastructure**
- `AGENTS.md`: rewritten with SteadRepo-derived git practices, branch naming, commit convention, OSS strategy, escalation rules, final response format
- `.github/pull_request_template.md`: structured PR template
- `.github/ISSUE_TEMPLATE/`: epic / story / enabler / bug templates
- `.github/workflows/test.yml`: GitHub Actions CI (note: requires repo to be public or GitHub Pro to run on private repo — add later)
- `pyproject.toml`: added `[project.optional-dependencies] dev = ["pytest>=8"]` and pytest config
- Repo moved from AI session path → `~/Developer/mac-care`

**New modules**
- `src/mac_care/git_safety.py`: `find_git_repos()`, `is_dirty()`, `has_active_worktrees()`, `unsafe_repos()` — detects live/dirty repos before any cleanup action touches workspace paths
- `src/mac_care/tools/brew.py`: parses `brew cleanup --dry-run` into per-item `auto_safe` findings
- `src/mac_care/tools/disk.py`: `size_of()` / `top_subdirs()` / `top_subdirs_summary()` — fast disk analysis via dua (primary), macOS `du` (fallback), Python rglob (last resort)
- `src/mac_care/tools/docker_check.py`: `docker system df` → reclaimable-space findings per category, all `review` risk
- `src/mac_care/tools/pearcleaner.py`: `pearcleaner list-orphaned` → orphaned app support file findings, all `review` risk

**Modified modules**
- `src/mac_care/model.py`: added `source` field to `Finding` (`native` | `brew` | `dua` | `docker` | `pearcleaner`)
- `src/mac_care/scan.py`: wires all OSS tool integrations; uses `size_of()` instead of `path_size()`; enriches reasons for large dirs (>500 MB) with top-subdir breakdown; git safety gate in `_codex_workspace_review()`
- `src/mac_care/clean.py`: git safety re-check before any workspace-adjacent action
- `src/mac_care/doctor.py`: `TOOL_RECOMMENDATIONS` dict, `recommend_tools()` function, `pearcleaner` added to optional tools
- `src/mac_care/cli.py`: `tools recommend` subcommand

## Validation
- [x] `python -m pytest tests/` — 73 passed in 0.29s
- [x] `mac-care scan` — 97 findings, 25.4 GB observed (brew, docker, dua, native)
- [x] `mac-care tools recommend` — grouped output, only missing tools shown
- [x] `mac-care clean --safe --dry-run` — no deletions, dry-run confirmed
- [x] Codex workspaces correctly marked `protected` (dirty git repos detected)
- [x] All OSS wrappers degrade gracefully when tool not installed

## Risks / Follow-ups
- GitHub Actions CI will not run on private repo without GitHub Pro — workflow file is ready for when repo goes public or Pro is added
- Branch protection on `main` also blocked by same constraint
- `pearcleaner` not yet installed on this machine — integration tested with mocks only; live test pending `brew install --cask pearcleaner`
- `schedule install/uninstall` (launchd) deferred to next sprint