### PR TITLE
feat: add report dashboard, scheduling, and quarantine workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ App cleanup:
 
 Prints what would be cleaned from `auto_safe` findings. Does not delete anything.
 
-> `--execute` is planned but not yet active — see [roadmap](#roadmap).
+### `mac-care clean --safe --execute`
+
+Moves eligible `auto_safe` findings to the configured quarantine directory. This is intentionally narrower than scan output: broad containers such as `~/Library/Caches` and `/tmp` are skipped until scan itemizes their contents.
 
 ---
 
@@ -192,7 +194,7 @@ Tests never touch the real filesystem and never call real external tools — all
 | 🔜 | `mac-care schedule install/uninstall` — launchd plist for periodic automated scan |
 | 🔜 | `mac-care scan --stdout --format json` — pipe-friendly output |
 | 🔜 | `mac-care security` — KnockKnock (Objective-See) integration for login items, browser extensions |
-| 🗓 | `mac-care clean --safe --execute` — move files to quarantine dir instead of `rm` |
+| ✅ | `mac-care clean --safe --execute` — move eligible files to quarantine dir instead of `rm` |
 | 🗓 | Interactive review flow for `review`-class findings |
 | 🗓 | Report history and trending — compare consecutive scans |
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ Prints what would be cleaned from `auto_safe` findings. Does not delete anything
 
 Moves eligible `auto_safe` findings to the configured quarantine directory. This is intentionally narrower than scan output: broad containers such as `~/Library/Caches` and `/tmp` are skipped until scan itemizes their contents.
 
+### `mac-care review approve`
+
+Approves one `review` finding from a JSON report by stable finding ID. Dry-run is the default.
+
+```bash
+mac-care review approve --report ~/Documents/MacCare/reports/mac-care-2026-05-02-220005.json --finding-id abc123
+mac-care review approve --report ~/Documents/MacCare/reports/mac-care-2026-05-02-220005.json --finding-id abc123 --execute
+```
+
 ---
 
 ## Risk levels
@@ -195,7 +204,7 @@ Tests never touch the real filesystem and never call real external tools — all
 | 🔜 | `mac-care scan --stdout --format json` — pipe-friendly output |
 | 🔜 | `mac-care security` — KnockKnock (Objective-See) integration for login items, browser extensions |
 | ✅ | `mac-care clean --safe --execute` — move eligible files to quarantine dir instead of `rm` |
-| 🗓 | Interactive review flow for `review`-class findings |
+| ✅ | Interactive review flow for `review`-class findings |
 | 🗓 | Report history and trending — compare consecutive scans |
 
 See [`docs/technical-spec.md`](docs/technical-spec.md) for full feature status, known constraints, and decision log.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,6 +153,8 @@ CLI source verified from [alienator88/Pearcleaner — Logic/CLI.swift](https://g
 
 All findings are `review` risk — never auto-cleaned.
 
+Live validation note: Pearcleaner 5.4.3 installed via Homebrew cask and `pearcleaner --help` confirms the `list-orphaned` subcommand. On this machine, `pearcleaner list-orphaned` did not return within 60 seconds, so the wrapper timeout is part of the safety contract and should remain fail-closed to `[]`.
+
 ---
 
 ## Report Structure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,8 @@ Acts on `auto_safe` findings only. Re-checks the git safety gate before touching
 
 **Rule:** Only `auto_safe` risk findings are eligible. `review` and `protected` are never touched.
 
+`--execute` moves eligible item-level/rebuildable findings to quarantine. Broad container findings such as `user_caches`, `user_logs`, `trash`, and `tmp` remain skipped until scan itemizes their contents. Every move writes metadata with the original path, quarantine path, risk, source, reason, and timestamp.
+
 ### `doctor.py`
 Checks required developer tools (`REQUIRED_TOOLS`), optional OSS integrations (`OSS_OPTIONAL_TOOLS`), Homebrew PATH, and Docker daemon reachability. `recommend_tools()` returns missing optional tools with install hints from `TOOL_RECOMMENDATIONS`.
 
@@ -200,4 +202,4 @@ These must hold at all times. Tests should catch regressions.
 4. Git safety gate returns `True` (unsafe) on any subprocess failure — never silently clears a repo.
 5. Every `tools/` wrapper returns `[]` on any error — never propagates exceptions to the caller.
 6. `dry_run=True` is the default for `safe_clean()`. Callers must explicitly pass `dry_run=False` to act.
-7. Deletion (when implemented) moves to `quarantine_dir`, never `rm`.
+7. Execution moves to `quarantine_dir`, never `rm`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,13 @@ Loads `~/.config/mac-care/config.toml` with fallback to hardcoded defaults. Retu
 ### `report.py`
 Writes Markdown + JSON reports to `config.reports_dir`. Reports are timestamped and never overwritten. The Markdown groups findings by risk level with size totals.
 
+JSON report findings include a stable `id` derived from category, path, risk, source, and reason. Review approval actions must reference this ID rather than accepting arbitrary paths from user input.
+
+### `review.py`
+Loads a known JSON report and approves one `review` finding by stable ID. The first command path is dry-run; execution delegates to the quarantine move path in `clean.py`.
+
+**Rule:** `protected` findings are rejected, and arbitrary filesystem paths are never accepted from the review command.
+
 ### `scheduler.py` *(planned)*
 Will write/remove a launchd plist at `~/Library/LaunchAgents/com.mac-care.periodic.plist` that runs `mac-care scan` on a configurable interval. Must support `--dry-run` to print the plist without writing it.
 
@@ -203,3 +210,4 @@ These must hold at all times. Tests should catch regressions.
 5. Every `tools/` wrapper returns `[]` on any error — never propagates exceptions to the caller.
 6. `dry_run=True` is the default for `safe_clean()`. Callers must explicitly pass `dry_run=False` to act.
 7. Execution moves to `quarantine_dir`, never `rm`.
+8. Review approval accepts only stable finding IDs from known reports, never arbitrary browser/CLI paths.

--- a/docs/dashboard-action-safety.md
+++ b/docs/dashboard-action-safety.md
@@ -1,0 +1,127 @@
+# Dashboard Action Backend Safety Model
+
+This document defines the safety contract for any future local dashboard backend.
+
+The current HTML dashboard is static and read-only. It must stay that way until this backend contract is implemented and tested.
+
+## Goals
+
+- Let a local report UI preview approved actions for known findings.
+- Preserve the CLI/report engine as the source of truth.
+- Prevent remote access, arbitrary command execution, and accidental cleanup.
+- Keep destructive behavior impossible until quarantine execution exists.
+
+## Network Boundary
+
+- Bind only to `127.0.0.1`.
+- Never bind to `0.0.0.0`, LAN interfaces, or public addresses.
+- Use an unpredictable session token in the dashboard URL.
+- Reject every request that does not include the active token.
+- Generate a new token every time the backend starts.
+- Do not persist tokens to disk.
+
+## Input Model
+
+The backend may only accept stable finding IDs that come from a known mac-care report.
+
+Allowed input:
+
+- report ID or report path under `config.reports_dir`
+- finding ID from that report
+- explicit action name from an allowlist
+
+Rejected input:
+
+- arbitrary filesystem paths from the browser
+- arbitrary shell commands
+- URLs
+- environment variable overrides
+- unrecognized action names
+
+## Action Phases
+
+### Phase 1: Preview Only
+
+The first backend implementation must be preview-only.
+
+Allowed actions:
+
+- list reports
+- list findings
+- show finding details
+- show planned CLI-equivalent action
+- open report files
+
+Disallowed actions:
+
+- move files
+- delete files
+- run cleanup
+- invoke Docker/Pearcleaner cleanup
+- modify launchd jobs
+
+### Phase 2: Quarantine Only
+
+After quarantine execution exists, the backend may call the same internal quarantine path as the CLI.
+
+Requirements:
+
+- require a confirmation request separate from preview
+- accept only `auto_safe` findings unless review approval flow exists
+- re-check protected paths immediately before action
+- re-check git safety immediately before workspace-adjacent action
+- move to `config.quarantine_dir`, never delete directly
+- write an action log entry with original path, quarantine path, timestamp, risk, source, and report ID
+
+### Phase 3: Review Approval
+
+Review-risk findings may be actioned only after the review approval flow exists.
+
+Requirements:
+
+- approve individual finding IDs, not categories
+- show exact planned move before execution
+- never act on `protected` findings
+- keep Docker, browser data, and app leftovers review-only
+
+## Required Re-checks
+
+The backend must not trust report data alone.
+
+Before any action preview or execution:
+
+- load the referenced report from `config.reports_dir`
+- verify the finding ID exists in that report
+- verify the path is still under the finding
+- re-run protected path checks
+- re-run git safety checks for workspace-adjacent categories
+- reject stale reports if the finding path no longer exists or has changed in a way that invalidates the plan
+
+## Endpoint Shape
+
+Initial preview-only endpoints:
+
+```text
+GET  /reports
+GET  /reports/{report_id}
+GET  /reports/{report_id}/findings/{finding_id}
+POST /reports/{report_id}/findings/{finding_id}/preview
+```
+
+Future quarantine endpoints:
+
+```text
+POST /reports/{report_id}/findings/{finding_id}/quarantine-preview
+POST /reports/{report_id}/findings/{finding_id}/quarantine-confirm
+```
+
+All endpoints require the session token.
+
+## Non-goals
+
+- No remote dashboard.
+- No cloud sync.
+- No arbitrary command runner.
+- No direct permanent delete.
+- No cleanup from notification actions.
+- No browser session cleanup until a separate privacy-specific review flow exists.

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -27,6 +27,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Developer tool health | `mac-care doctor` | Required tools, Homebrew PATH, Docker daemon |
 | Tool status | `mac-care tools status` | Required + optional tools installed/missing |
 | Tool recommendations | `mac-care tools recommend` | Missing OSS tools with `brew install` hints, grouped |
+| Compact scan summary | `mac-care scan` | Counts and sizes by risk, top findings, tool warning count |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
 | Markdown + JSON reports | `mac-care scan` | Timestamped, written to `~/Documents/MacCare/reports/` |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
@@ -125,11 +126,12 @@ Key categories protected by default:
 
 ## Test Coverage
 
-73 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+75 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
 | `tests/test_report.py` | Markdown rendering, risk grouping |
+| `tests/test_summary.py` | Risk totals, top findings, tool warning count |
 | `tests/test_git_safety.py` | `find_git_repos`, `is_dirty`, `has_active_worktrees`, `unsafe_repos` — all degradation paths |
 | `tests/test_doctor.py` | `recommend_tools` — missing/installed/empty/key/brew-prefix |
 | `tests/tools/test_brew.py` | `_parse_size`, full parse, sizes, risk/source tagging, all degradation |
@@ -146,6 +148,22 @@ Key categories protected by default:
 ---
 
 ## Example scan output shape
+
+Reports include a reusable compact summary used by CLI output and intended for future HTML reports and notifications:
+
+```json
+{
+  "summary": {
+    "risks": {
+      "auto_safe": {"count": 12, "size_bytes": 109000000},
+      "review": {"count": 4, "size_bytes": 9800000000},
+      "protected": {"count": 1, "size_bytes": 3200000000}
+    },
+    "top_findings": [],
+    "tool_warning_count": 2
+  }
+}
+```
 
 | Source | Category examples | Risk |
 |---|---|---|

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -28,6 +28,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Tool status | `mac-care tools status` | Required + optional tools installed/missing |
 | Tool recommendations | `mac-care tools recommend` | Missing OSS tools with `brew install` hints, grouped |
 | Compact scan summary | `mac-care scan` | Counts and sizes by risk, top findings, tool warning count |
+| Scan output flags | `mac-care scan --stdout` | Print JSON or Markdown to stdout for piping; skip writing files |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
 | Markdown + JSON reports | `mac-care scan` | Timestamped, written to `~/Documents/MacCare/reports/` |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
@@ -126,10 +127,11 @@ Key categories protected by default:
 
 ## Test Coverage
 
-75 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+79 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
+| `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
 | `tests/test_report.py` | Markdown rendering, risk grouping |
 | `tests/test_summary.py` | Risk totals, top findings, tool warning count |
 | `tests/test_git_safety.py` | `find_git_repos`, `is_dirty`, `has_active_worktrees`, `unsafe_repos` — all degradation paths |
@@ -163,6 +165,13 @@ Reports include a reusable compact summary used by CLI output and intended for f
     "tool_warning_count": 2
   }
 }
+```
+
+Pipe-friendly scan output skips file writing and emits a single report format:
+
+```bash
+mac-care scan --stdout --format json
+mac-care scan --stdout --format markdown
 ```
 
 | Source | Category examples | Risk |

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -35,6 +35,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | macOS scan notification | `mac-care scan --notify` | Posts compact scan summary through `osascript`; degrades gracefully |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
 | Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/Documents/MacCare/reports/` |
+| Report history index | `mac-care scan` | Writes read-only `index.html` listing previous JSON/Markdown/dashboard reports |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
 | GitHub Actions CI | `.github/workflows/test.yml` | `macos-latest`, Python 3.11, 73 tests |
 | Branch protection | GitHub | Requires CI to pass before merge to main |
@@ -58,7 +59,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 |---|---|---|
 | Compact scan summary model | [#8](https://github.com/djspiceroute/mac-care/issues/8) | Lightweight summary struct for dashboard and notifications |
 | HTML dashboard from scan results | [#9](https://github.com/djspiceroute/mac-care/issues/9) | Static HTML report generated alongside Markdown + JSON |
-| Report history index | [#10](https://github.com/djspiceroute/mac-care/issues/10) | Track consecutive scans; surface what grew since last run |
+| Report history index | [#10](https://github.com/djspiceroute/mac-care/issues/10) | Implemented as read-only `index.html`; trend deltas remain future work |
 | Stdout and format flags | [#6](https://github.com/djspiceroute/mac-care/issues/6) | `mac-care scan --stdout --format json/markdown` for piping |
 
 #### Epic: Periodic local scan workflow ([#3](https://github.com/djspiceroute/mac-care/issues/3))
@@ -131,11 +132,12 @@ Key categories protected by default:
 
 ## Test Coverage
 
-91 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+95 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
 | `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
+| `tests/test_history.py` | Report history loading, malformed report skipping, index rendering/writing |
 | `tests/test_notification.py` | Notification text and graceful `osascript` delivery behavior |
 | `tests/test_scheduler.py` | launchd plist rendering, dry-run install/uninstall, plist write/remove using temp paths |
 | `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard |
@@ -192,6 +194,8 @@ mac-care schedule uninstall
 ```
 
 Scheduled scans use `mac-care scan --notify`, which writes reports and posts a compact macOS notification. Notification delivery failures are ignored so scan/report generation still succeeds.
+
+Each default scan also updates `index.html` in the reports directory. The index is read-only and lists historical JSON/Markdown/dashboard reports in reverse chronological order, skipping malformed JSON reports safely.
 
 | Source | Category examples | Risk |
 |---|---|---|

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -31,7 +31,8 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Scan output flags | `mac-care scan --stdout` | Print JSON or Markdown to stdout for piping; skip writing files |
 | launchd schedule | `mac-care schedule install` | Writes scan-only plist to `~/Library/LaunchAgents/`; `--dry-run` prints plist |
 | launchd uninstall | `mac-care schedule uninstall` | Removes plist and attempts launchctl unload; `--dry-run` prints planned removal |
-| Schedule interval config | `--interval <hours>` | Default 24h; uses launchd `StartInterval`; runs `mac-care scan` only |
+| Schedule interval config | `--interval <hours>` | Default 24h; uses launchd `StartInterval`; runs `mac-care scan --notify` only |
+| macOS scan notification | `mac-care scan --notify` | Posts compact scan summary through `osascript`; degrades gracefully |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
 | Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/Documents/MacCare/reports/` |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
@@ -124,17 +125,18 @@ Key categories protected by default:
 - **`gdu` name collision.** `brew install coreutils` puts a `gdu` binary on PATH that is GNU `du`, not the Go disk usage analyzer. `tools/disk.py` uses `dua` as primary — `gdu` integration is deferred until resolved (possible fix: fingerprint binary via `--help` output before use).
 - **Pearcleaner not yet live-tested.** `tools/pearcleaner.py` is complete and tested with mocks. Live test pending issue #7.
 - **No scan output format flags yet.** `mac-care scan` always writes both files. `--stdout --format json/markdown` is in progress (issue #6).
-- **Notifications not yet built.** Scheduled scans generate reports/logs but do not post macOS notifications until issue #11 lands.
+- **Interactive notification actions are not implemented.** Notifications summarize the scan only; review still happens in reports.
 
 ---
 
 ## Test Coverage
 
-87 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+91 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
 | `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
+| `tests/test_notification.py` | Notification text and graceful `osascript` delivery behavior |
 | `tests/test_scheduler.py` | launchd plist rendering, dry-run install/uninstall, plist write/remove using temp paths |
 | `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard |
 | `tests/test_summary.py` | Risk totals, top findings, tool warning count |
@@ -188,6 +190,8 @@ mac-care schedule install --interval 24
 mac-care schedule uninstall --dry-run
 mac-care schedule uninstall
 ```
+
+Scheduled scans use `mac-care scan --notify`, which writes reports and posts a compact macOS notification. Notification delivery failures are ignored so scan/report generation still succeeds.
 
 | Source | Category examples | Risk |
 |---|---|---|

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -34,6 +34,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Schedule interval config | `--interval <hours>` | Default 24h; uses launchd `StartInterval`; runs `mac-care scan --notify` only |
 | macOS scan notification | `mac-care scan --notify` | Posts compact scan summary through `osascript`; degrades gracefully |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
+| Quarantine cleanup execution | `mac-care clean --safe --execute` | Moves eligible `auto_safe` findings to quarantine with metadata; never `rm` |
 | Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/Documents/MacCare/reports/` |
 | Report history index | `mac-care scan` | Writes read-only `index.html` listing previous JSON/Markdown/dashboard reports |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
@@ -49,7 +50,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 
 | Feature | Issue | Notes |
 |---|---|---|
-| Move `auto_safe` findings to quarantine | [#12](https://github.com/djspiceroute/mac-care/issues/12) | `mac-care clean --safe --execute` moves to `quarantine_dir`, never `rm` |
+| Move `auto_safe` findings to quarantine | [#12](https://github.com/djspiceroute/mac-care/issues/12) | Implemented for eligible item-level/rebuildable findings; broad containers remain skipped |
 | Review approval flow | [#13](https://github.com/djspiceroute/mac-care/issues/13) | Interactive per-item confirmation for `review` findings |
 | Dashboard action safety model | [#14](https://github.com/djspiceroute/mac-care/issues/14) | Documented in `docs/dashboard-action-safety.md`; implementation remains future work |
 
@@ -122,7 +123,7 @@ Key categories protected by default:
 
 ## Known Constraints
 
-- **No deletion implemented yet.** `mac-care clean --safe` only operates in dry-run mode. The `--execute` path is a stub pending quarantine implementation (issue #12).
+- **Quarantine execution is intentionally narrow.** `mac-care clean --safe --execute` moves eligible `auto_safe` findings to quarantine, but broad container findings such as `user_caches`, `user_logs`, `trash`, and `tmp` are skipped until scan itemizes their contents.
 - **`gdu` name collision.** `brew install coreutils` puts a `gdu` binary on PATH that is GNU `du`, not the Go disk usage analyzer. `tools/disk.py` uses `dua` as primary — `gdu` integration is deferred until resolved (possible fix: fingerprint binary via `--help` output before use).
 - **Pearcleaner live constraint.** Pearcleaner 5.4.3 installed successfully via Homebrew cask and linked `/opt/homebrew/bin/pearcleaner`. `pearcleaner --help` confirms `list-orphaned`, but the real `pearcleaner list-orphaned` call did not return within 60 seconds on this machine. The wrapper's timeout path returned `[]` as intended, so scans stay responsive and Pearcleaner findings remain optional/review-only.
 - **No scan output format flags yet.** `mac-care scan` always writes both files. `--stdout --format json/markdown` is in progress (issue #6).
@@ -132,10 +133,11 @@ Key categories protected by default:
 
 ## Test Coverage
 
-95 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+100 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
+| `tests/test_clean.py` | Dry-run default, quarantine moves, metadata, protected-path re-check, non-itemized skip |
 | `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
 | `tests/test_history.py` | Report history loading, malformed report skipping, index rendering/writing |
 | `tests/test_notification.py` | Notification text and graceful `osascript` delivery behavior |

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -29,6 +29,9 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Tool recommendations | `mac-care tools recommend` | Missing OSS tools with `brew install` hints, grouped |
 | Compact scan summary | `mac-care scan` | Counts and sizes by risk, top findings, tool warning count |
 | Scan output flags | `mac-care scan --stdout` | Print JSON or Markdown to stdout for piping; skip writing files |
+| launchd schedule | `mac-care schedule install` | Writes scan-only plist to `~/Library/LaunchAgents/`; `--dry-run` prints plist |
+| launchd uninstall | `mac-care schedule uninstall` | Removes plist and attempts launchctl unload; `--dry-run` prints planned removal |
+| Schedule interval config | `--interval <hours>` | Default 24h; uses launchd `StartInterval`; runs `mac-care scan` only |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
 | Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/Documents/MacCare/reports/` |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
@@ -121,17 +124,18 @@ Key categories protected by default:
 - **`gdu` name collision.** `brew install coreutils` puts a `gdu` binary on PATH that is GNU `du`, not the Go disk usage analyzer. `tools/disk.py` uses `dua` as primary — `gdu` integration is deferred until resolved (possible fix: fingerprint binary via `--help` output before use).
 - **Pearcleaner not yet live-tested.** `tools/pearcleaner.py` is complete and tested with mocks. Live test pending issue #7.
 - **No scan output format flags yet.** `mac-care scan` always writes both files. `--stdout --format json/markdown` is in progress (issue #6).
-- **launchd scheduler not yet built.** Periodic automated scanning requires `mac-care schedule install` (issue #5).
+- **Notifications not yet built.** Scheduled scans generate reports/logs but do not post macOS notifications until issue #11 lands.
 
 ---
 
 ## Test Coverage
 
-80 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+87 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
 | `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
+| `tests/test_scheduler.py` | launchd plist rendering, dry-run install/uninstall, plist write/remove using temp paths |
 | `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard |
 | `tests/test_summary.py` | Risk totals, top findings, tool warning count |
 | `tests/test_git_safety.py` | `find_git_repos`, `is_dirty`, `has_active_worktrees`, `unsafe_repos` — all degradation paths |
@@ -175,6 +179,15 @@ mac-care scan --stdout --format markdown
 ```
 
 Default scan writes `latest.html` as a static local dashboard alongside timestamped Markdown and JSON reports. The HTML is read-only by design: it summarizes findings, risk groups, top findings, and doctor output, but does not include cleanup action controls.
+
+Periodic scan scheduling is launchd-based and scan-only:
+
+```bash
+mac-care schedule install --dry-run
+mac-care schedule install --interval 24
+mac-care schedule uninstall --dry-run
+mac-care schedule uninstall
+```
 
 | Source | Category examples | Risk |
 |---|---|---|

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -72,7 +72,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 
 | Feature | Issue | Notes |
 |---|---|---|
-| Pearcleaner live test | [#7](https://github.com/djspiceroute/mac-care/issues/7) | Install and run real scan; integration is mock-tested only today |
+| Pearcleaner live test | [#7](https://github.com/djspiceroute/mac-care/issues/7) | Installed cask and verified CLI; `list-orphaned` timed out live |
 
 ---
 
@@ -101,7 +101,7 @@ All are optional — mac-care degrades gracefully when absent.
 | `dust` | `brew install dust` | `tools/disk.py` (planned secondary) | Rust-based directory size tree |
 | `gdu` | `brew install gdu` | Not integrated | Name collision with GNU `du` on machines with `coreutils` installed |
 | `ncdu` | `brew install ncdu` | Not integrated | Interactive ncurses disk usage |
-| `pearcleaner` | `brew install --cask pearcleaner` | `tools/pearcleaner.py` | Pending live test (#7) |
+| `pearcleaner` | `brew install --cask pearcleaner` | `tools/pearcleaner.py` | CLI verified; `list-orphaned` timed out live |
 | `mas` | `brew install mas` | Not yet integrated | Mac App Store CLI |
 | KnockKnock | Manual download (Objective-See) | Planned `mac-care security` | Security persistence scanner |
 
@@ -123,7 +123,7 @@ Key categories protected by default:
 
 - **No deletion implemented yet.** `mac-care clean --safe` only operates in dry-run mode. The `--execute` path is a stub pending quarantine implementation (issue #12).
 - **`gdu` name collision.** `brew install coreutils` puts a `gdu` binary on PATH that is GNU `du`, not the Go disk usage analyzer. `tools/disk.py` uses `dua` as primary — `gdu` integration is deferred until resolved (possible fix: fingerprint binary via `--help` output before use).
-- **Pearcleaner not yet live-tested.** `tools/pearcleaner.py` is complete and tested with mocks. Live test pending issue #7.
+- **Pearcleaner live constraint.** Pearcleaner 5.4.3 installed successfully via Homebrew cask and linked `/opt/homebrew/bin/pearcleaner`. `pearcleaner --help` confirms `list-orphaned`, but the real `pearcleaner list-orphaned` call did not return within 60 seconds on this machine. The wrapper's timeout path returned `[]` as intended, so scans stay responsive and Pearcleaner findings remain optional/review-only.
 - **No scan output format flags yet.** `mac-care scan` always writes both files. `--stdout --format json/markdown` is in progress (issue #6).
 - **Interactive notification actions are not implemented.** Notifications summarize the scan only; review still happens in reports.
 
@@ -216,5 +216,6 @@ Scheduled scans use `mac-care scan --notify`, which writes reports and posts a c
 | 2026-05-02 | `gdu` integration deferred | Name collision with GNU du — needs binary fingerprinting before use |
 | 2026-05-02 | Docker findings all `review` | Docker cleanup is stateful and non-trivial; always require user intent |
 | 2026-05-02 | Pearcleaner all `review` | Orphaned file determination is heuristic; human confirmation is necessary |
+| 2026-05-02 | Keep Pearcleaner timeout degradation | Live `list-orphaned` can hang; wrapper should return `[]` rather than block scan |
 | 2026-05-02 | Quarantine dir instead of `rm` | One-way door prevention; files can be recovered from quarantine |
 | 2026-05-02 | Repo made public | Enables GitHub Actions CI and branch protection on free tier |

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -35,6 +35,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | macOS scan notification | `mac-care scan --notify` | Posts compact scan summary through `osascript`; degrades gracefully |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
 | Quarantine cleanup execution | `mac-care clean --safe --execute` | Moves eligible `auto_safe` findings to quarantine with metadata; never `rm` |
+| Review approval flow | `mac-care review approve` | Approves one `review` finding by stable report finding ID; quarantine-only on execute |
 | Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/Documents/MacCare/reports/` |
 | Report history index | `mac-care scan` | Writes read-only `index.html` listing previous JSON/Markdown/dashboard reports |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
@@ -51,7 +52,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Feature | Issue | Notes |
 |---|---|---|
 | Move `auto_safe` findings to quarantine | [#12](https://github.com/djspiceroute/mac-care/issues/12) | Implemented for eligible item-level/rebuildable findings; broad containers remain skipped |
-| Review approval flow | [#13](https://github.com/djspiceroute/mac-care/issues/13) | Interactive per-item confirmation for `review` findings |
+| Review approval flow | [#13](https://github.com/djspiceroute/mac-care/issues/13) | Implemented as stable-ID approval from JSON reports; dashboard wiring remains future work |
 | Dashboard action safety model | [#14](https://github.com/djspiceroute/mac-care/issues/14) | Documented in `docs/dashboard-action-safety.md`; implementation remains future work |
 
 #### Epic: Unified local report viewer ([#2](https://github.com/djspiceroute/mac-care/issues/2))
@@ -133,16 +134,18 @@ Key categories protected by default:
 
 ## Test Coverage
 
-100 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+107 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
 | `tests/test_clean.py` | Dry-run default, quarantine moves, metadata, protected-path re-check, non-itemized skip |
 | `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
 | `tests/test_history.py` | Report history loading, malformed report skipping, index rendering/writing |
+| `tests/test_ids.py` | Stable finding ID behavior |
 | `tests/test_notification.py` | Notification text and graceful `osascript` delivery behavior |
 | `tests/test_scheduler.py` | launchd plist rendering, dry-run install/uninstall, plist write/remove using temp paths |
 | `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard |
+| `tests/test_review.py` | Review approval dry-run, quarantine execution, protected/unknown finding rejection |
 | `tests/test_summary.py` | Risk totals, top findings, tool warning count |
 | `tests/test_git_safety.py` | `find_git_repos`, `is_dirty`, `has_active_worktrees`, `unsafe_repos` — all degradation paths |
 | `tests/test_doctor.py` | `recommend_tools` — missing/installed/empty/key/brew-prefix |
@@ -174,6 +177,20 @@ Reports include a reusable compact summary used by CLI output and intended for f
     "top_findings": [],
     "tool_warning_count": 2
   }
+}
+```
+
+JSON report findings also include stable IDs used for review approval:
+
+```json
+{
+  "findings": [
+    {
+      "id": "3b6d0f0d9a8c1e2f",
+      "category": "orphaned_app_files",
+      "risk": "review"
+    }
+  ]
 }
 ```
 

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -30,7 +30,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Compact scan summary | `mac-care scan` | Counts and sizes by risk, top findings, tool warning count |
 | Scan output flags | `mac-care scan --stdout` | Print JSON or Markdown to stdout for piping; skip writing files |
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
-| Markdown + JSON reports | `mac-care scan` | Timestamped, written to `~/Documents/MacCare/reports/` |
+| Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/Documents/MacCare/reports/` |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
 | GitHub Actions CI | `.github/workflows/test.yml` | `macos-latest`, Python 3.11, 73 tests |
 | Branch protection | GitHub | Requires CI to pass before merge to main |
@@ -127,12 +127,12 @@ Key categories protected by default:
 
 ## Test Coverage
 
-79 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+80 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
 | `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
-| `tests/test_report.py` | Markdown rendering, risk grouping |
+| `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard |
 | `tests/test_summary.py` | Risk totals, top findings, tool warning count |
 | `tests/test_git_safety.py` | `find_git_repos`, `is_dirty`, `has_active_worktrees`, `unsafe_repos` — all degradation paths |
 | `tests/test_doctor.py` | `recommend_tools` — missing/installed/empty/key/brew-prefix |
@@ -173,6 +173,8 @@ Pipe-friendly scan output skips file writing and emits a single report format:
 mac-care scan --stdout --format json
 mac-care scan --stdout --format markdown
 ```
+
+Default scan writes `latest.html` as a static local dashboard alongside timestamped Markdown and JSON reports. The HTML is read-only by design: it summarizes findings, risk groups, top findings, and doctor output, but does not include cleanup action controls.
 
 | Source | Category examples | Risk |
 |---|---|---|

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -51,7 +51,7 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 |---|---|---|
 | Move `auto_safe` findings to quarantine | [#12](https://github.com/djspiceroute/mac-care/issues/12) | `mac-care clean --safe --execute` moves to `quarantine_dir`, never `rm` |
 | Review approval flow | [#13](https://github.com/djspiceroute/mac-care/issues/13) | Interactive per-item confirmation for `review` findings |
-| Dashboard action safety model | [#14](https://github.com/djspiceroute/mac-care/issues/14) | Backend safety contract for any UI-triggered cleanup |
+| Dashboard action safety model | [#14](https://github.com/djspiceroute/mac-care/issues/14) | Documented in `docs/dashboard-action-safety.md`; implementation remains future work |
 
 #### Epic: Unified local report viewer ([#2](https://github.com/djspiceroute/mac-care/issues/2))
 

--- a/src/mac_care/clean.py
+++ b/src/mac_care/clean.py
@@ -53,21 +53,32 @@ def safe_clean(findings: list[Finding], config: Config | None = None, dry_run: b
             )
             continue
 
-        path = Path(finding.path).expanduser()
-        if _is_protected(path, config):
-            actions.append(f"skipped execution for {finding.category}: protected path {path}")
-            continue
-
-        if not path.exists():
-            actions.append(f"skipped execution for {finding.category}: path no longer exists {path}")
-            continue
-
-        destination = _quarantine_path(config, finding, run_id)
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(path), str(destination))
-        _write_metadata(destination.parent, destination, finding)
-        actions.append(f"quarantined {finding.category}: {path} -> {destination}")
+        actions.append(quarantine_finding(finding, config, run_id=run_id))
     return actions
+
+
+def quarantine_finding(finding: Finding, config: Config, run_id: str | None = None) -> str:
+    run_id = run_id or datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    path = Path(finding.path).expanduser()
+    if _is_protected(path, config):
+        return f"skipped execution for {finding.category}: protected path {path}"
+
+    if finding.category in _WORKSPACE_CATEGORIES:
+        dirty = unsafe_repos(path)
+        if dirty:
+            return (
+                f"skipped {finding.category}: unsafe git repos detected at execution time — "
+                f"{', '.join(str(r) for r in dirty[:2])}"
+            )
+
+    if not path.exists():
+        return f"skipped execution for {finding.category}: path no longer exists {path}"
+
+    destination = _quarantine_path(config, finding, run_id)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(path), str(destination))
+    _write_metadata(destination.parent, destination, finding)
+    return f"quarantined {finding.category}: {path} -> {destination}"
 
 
 def _is_protected(path: Path, config: Config) -> bool:

--- a/src/mac_care/clean.py
+++ b/src/mac_care/clean.py
@@ -1,16 +1,27 @@
 from __future__ import annotations
 
+from datetime import datetime
+import json
 from pathlib import Path
+import shutil
+import uuid
 
+from .config import Config
 from .git_safety import unsafe_repos
 from .model import Finding
 
 # Categories whose paths may contain git repos — always re-check before acting.
 _WORKSPACE_CATEGORIES = {"codex_workspaces"}
 
+# First execution path only supports item-level or rebuildable directory moves.
+# Broad containers like ~/Library/Caches and /tmp stay dry-run-only until scan
+# itemizes their contents.
+_EXECUTABLE_AUTO_SAFE_CATEGORIES = {"brew_cache", "xcode_derived_data"}
 
-def safe_clean(findings: list[Finding], dry_run: bool = True) -> list[str]:
+
+def safe_clean(findings: list[Finding], config: Config | None = None, dry_run: bool = True) -> list[str]:
     actions: list[str] = []
+    run_id = datetime.now().strftime("%Y-%m-%d-%H%M%S")
     for finding in findings:
         if finding.risk != "auto_safe":
             continue
@@ -28,8 +39,78 @@ def safe_clean(findings: list[Finding], dry_run: bool = True) -> list[str]:
 
         if dry_run:
             actions.append(f"would clean {finding.category}: {finding.path}")
-        else:
+            continue
+
+        if config is None:
             actions.append(
-                f"skipped execution for {finding.category}: deletion policies are not implemented yet"
+                f"skipped execution for {finding.category}: config is required for quarantine"
             )
+            continue
+
+        if finding.category not in _EXECUTABLE_AUTO_SAFE_CATEGORIES:
+            actions.append(
+                f"skipped execution for {finding.category}: category is not itemized for quarantine yet"
+            )
+            continue
+
+        path = Path(finding.path).expanduser()
+        if _is_protected(path, config):
+            actions.append(f"skipped execution for {finding.category}: protected path {path}")
+            continue
+
+        if not path.exists():
+            actions.append(f"skipped execution for {finding.category}: path no longer exists {path}")
+            continue
+
+        destination = _quarantine_path(config, finding, run_id)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(path), str(destination))
+        _write_metadata(destination.parent, destination, finding)
+        actions.append(f"quarantined {finding.category}: {path} -> {destination}")
     return actions
+
+
+def _is_protected(path: Path, config: Config) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    for protected in config.protected_paths:
+        try:
+            protected_resolved = protected.resolve()
+        except OSError:
+            protected_resolved = protected
+        if resolved == protected_resolved or protected_resolved in resolved.parents:
+            return True
+
+    quarantine = config.quarantine_dir.expanduser()
+    try:
+        quarantine_resolved = quarantine.resolve()
+    except OSError:
+        quarantine_resolved = quarantine
+    return resolved == quarantine_resolved or quarantine_resolved in resolved.parents
+
+
+def _quarantine_path(config: Config, finding: Finding, run_id: str) -> Path:
+    base = config.quarantine_dir.expanduser() / run_id / finding.category
+    source = Path(finding.path)
+    name = source.name or finding.category
+    candidate = base / name
+    if not candidate.exists():
+        return candidate
+    return base / f"{name}-{uuid.uuid4().hex[:8]}"
+
+
+def _write_metadata(run_dir: Path, destination: Path, finding: Finding) -> None:
+    metadata = {
+        "original_path": finding.path,
+        "quarantine_path": str(destination),
+        "category": finding.category,
+        "risk": finding.risk,
+        "source": finding.source,
+        "reason": finding.reason,
+        "size_bytes": finding.size_bytes,
+        "quarantined_at": datetime.now().isoformat(timespec="seconds"),
+    }
+    metadata_path = run_dir / f"{destination.name}.metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -8,6 +8,7 @@ from .doctor import check_tools, recommend_tools
 from .model import format_bytes
 from .report import render_json, render_markdown, write_reports
 from .scan import scan
+from .scheduler import install_schedule, uninstall_schedule
 from .summary import summarize_scan
 
 
@@ -39,6 +40,14 @@ def main() -> int:
     clean_parser.add_argument("--safe", action="store_true", help="Only consider auto_safe findings")
     clean_parser.add_argument("--dry-run", action="store_true", default=True, help="Do not delete anything")
 
+    schedule_parser = subparsers.add_parser("schedule", help="Manage periodic launchd scans")
+    schedule_subparsers = schedule_parser.add_subparsers(dest="schedule_action", required=True)
+    install_parser = schedule_subparsers.add_parser("install", help="Install periodic scan launchd plist")
+    install_parser.add_argument("--interval", type=int, default=24, help="Scan interval in hours")
+    install_parser.add_argument("--dry-run", action="store_true", default=False, help="Print plist without writing files")
+    uninstall_parser = schedule_subparsers.add_parser("uninstall", help="Uninstall periodic scan launchd plist")
+    uninstall_parser.add_argument("--dry-run", action="store_true", default=False, help="Print planned removal without changing files")
+
     args = parser.parse_args()
     config = Config.load(args.config)
 
@@ -54,6 +63,16 @@ def main() -> int:
         for status in check_tools(include_optional=True):
             print(f"{status.name}: {status.status} - {status.detail}")
         return 0
+
+    if args.command == "schedule":
+        if args.schedule_action == "install":
+            result = install_schedule(config, interval_hours=args.interval, dry_run=args.dry_run)
+            print(result.message)
+            return 0
+        if args.schedule_action == "uninstall":
+            result = uninstall_schedule(dry_run=args.dry_run)
+            print(result.message)
+            return 0
 
     findings = scan(config)
     tools = check_tools()

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from .clean import safe_clean
 from .config import Config
@@ -8,6 +9,7 @@ from .doctor import check_tools, recommend_tools
 from .model import format_bytes
 from .notification import notify_scan_complete
 from .report import render_json, render_markdown, write_reports
+from .review import approve_finding
 from .scan import scan
 from .scheduler import install_schedule, uninstall_schedule
 from .summary import summarize_scan
@@ -51,6 +53,14 @@ def main() -> int:
     uninstall_parser = schedule_subparsers.add_parser("uninstall", help="Uninstall periodic scan launchd plist")
     uninstall_parser.add_argument("--dry-run", action="store_true", default=False, help="Print planned removal without changing files")
 
+    review_parser = subparsers.add_parser("review", help="Approve review-risk findings from a report")
+    review_subparsers = review_parser.add_subparsers(dest="review_action", required=True)
+    approve_parser = review_subparsers.add_parser("approve", help="Approve one review-risk finding by ID")
+    approve_parser.add_argument("--report", required=True, help="Path to a mac-care JSON report")
+    approve_parser.add_argument("--finding-id", required=True, help="Stable finding ID from the report")
+    approve_parser.add_argument("--dry-run", action="store_true", default=True, help="Preview the approval action")
+    approve_parser.add_argument("--execute", action="store_true", help="Move the approved finding to quarantine")
+
     args = parser.parse_args()
     config = Config.load(args.config)
 
@@ -75,6 +85,20 @@ def main() -> int:
         if args.schedule_action == "uninstall":
             result = uninstall_schedule(dry_run=args.dry_run)
             print(result.message)
+            return 0
+
+    if args.command == "review":
+        if args.review_action == "approve":
+            print(
+                approve_finding(
+                    Path(args.report),
+                    args.finding_id,
+                    config,
+                    dry_run=not args.execute,
+                )
+            )
+            if not args.execute:
+                print("Dry run only. No files were moved.")
             return 0
 
     findings = scan(config)

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -41,6 +41,7 @@ def main() -> int:
     clean_parser = subparsers.add_parser("clean", help="Run safe cleanup policy")
     clean_parser.add_argument("--safe", action="store_true", help="Only consider auto_safe findings")
     clean_parser.add_argument("--dry-run", action="store_true", default=True, help="Do not delete anything")
+    clean_parser.add_argument("--execute", action="store_true", help="Move eligible auto_safe findings to quarantine")
 
     schedule_parser = subparsers.add_parser("schedule", help="Manage periodic launchd scans")
     schedule_subparsers = schedule_parser.add_subparsers(dest="schedule_action", required=True)
@@ -109,10 +110,10 @@ def main() -> int:
         return 0
 
     if args.command == "clean":
-        actions = safe_clean(findings, dry_run=args.dry_run)
+        actions = safe_clean(findings, config=config, dry_run=not args.execute)
         for action in actions:
             print(action)
-        if args.dry_run:
+        if not args.execute:
             print("Dry run only. No files were deleted.")
         return 0
 

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -8,6 +8,7 @@ from .doctor import check_tools, recommend_tools
 from .model import format_bytes
 from .report import write_reports
 from .scan import scan
+from .summary import summarize_scan
 
 
 def main() -> int:
@@ -52,8 +53,17 @@ def main() -> int:
 
     if args.command == "scan":
         md_path, json_path = write_reports(config, findings, tools)
+        summary = summarize_scan(findings, tools)
         total = sum(item.size_bytes for item in findings)
-        print(f"Scanned {len(findings)} findings, {format_bytes(total)} observed.")
+        review = summary.risks["review"]
+        auto_safe = summary.risks["auto_safe"]
+        protected = summary.risks["protected"]
+        print(
+            "Scanned "
+            f"{len(findings)} findings, {format_bytes(total)} observed "
+            f"({auto_safe.count} auto_safe / {review.count} review / {protected.count} protected; "
+            f"{summary.tool_warning_count} tool warnings)."
+        )
         print(f"Markdown report: {md_path}")
         print(f"JSON report: {json_path}")
         return 0

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -66,7 +66,7 @@ def main() -> int:
                 print(render_markdown(findings, tools))
             return 0
 
-        md_path, json_path = write_reports(config, findings, tools)
+        md_path, json_path, html_path = write_reports(config, findings, tools)
         summary = summarize_scan(findings, tools)
         total = sum(item.size_bytes for item in findings)
         review = summary.risks["review"]
@@ -80,6 +80,7 @@ def main() -> int:
         )
         print(f"Markdown report: {md_path}")
         print(f"JSON report: {json_path}")
+        print(f"HTML report: {html_path}")
         return 0
 
     if args.command == "clean":

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -6,6 +6,7 @@ from .clean import safe_clean
 from .config import Config
 from .doctor import check_tools, recommend_tools
 from .model import format_bytes
+from .notification import notify_scan_complete
 from .report import render_json, render_markdown, write_reports
 from .scan import scan
 from .scheduler import install_schedule, uninstall_schedule
@@ -19,6 +20,7 @@ def main() -> int:
 
     scan_parser = subparsers.add_parser("scan", help="Scan cleanup opportunities and write reports")
     scan_parser.add_argument("--stdout", action="store_true", help="Print report to stdout instead of writing files")
+    scan_parser.add_argument("--notify", action="store_true", help="Post a macOS notification after scan completes")
     scan_parser.add_argument(
         "--format",
         choices=["json", "markdown"],
@@ -78,15 +80,17 @@ def main() -> int:
     tools = check_tools()
 
     if args.command == "scan":
+        summary = summarize_scan(findings, tools)
         if args.stdout:
             if args.format == "json":
                 print(render_json(findings, tools))
             else:
                 print(render_markdown(findings, tools))
+            if args.notify:
+                notify_scan_complete(summary)
             return 0
 
         md_path, json_path, html_path = write_reports(config, findings, tools)
-        summary = summarize_scan(findings, tools)
         total = sum(item.size_bytes for item in findings)
         review = summary.risks["review"]
         auto_safe = summary.risks["auto_safe"]
@@ -100,6 +104,8 @@ def main() -> int:
         print(f"Markdown report: {md_path}")
         print(f"JSON report: {json_path}")
         print(f"HTML report: {html_path}")
+        if args.notify:
+            notify_scan_complete(summary)
         return 0
 
     if args.command == "clean":

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -6,7 +6,7 @@ from .clean import safe_clean
 from .config import Config
 from .doctor import check_tools, recommend_tools
 from .model import format_bytes
-from .report import write_reports
+from .report import render_json, render_markdown, write_reports
 from .scan import scan
 from .summary import summarize_scan
 
@@ -16,7 +16,14 @@ def main() -> int:
     parser.add_argument("--config", help="Path to config.toml")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    subparsers.add_parser("scan", help="Scan cleanup opportunities and write reports")
+    scan_parser = subparsers.add_parser("scan", help="Scan cleanup opportunities and write reports")
+    scan_parser.add_argument("--stdout", action="store_true", help="Print report to stdout instead of writing files")
+    scan_parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="markdown",
+        help="Output format when --stdout is used",
+    )
     subparsers.add_parser("doctor", help="Check developer tool health")
 
     tools_parser = subparsers.add_parser("tools", help="OSS tool status and recommendations")
@@ -52,6 +59,13 @@ def main() -> int:
     tools = check_tools()
 
     if args.command == "scan":
+        if args.stdout:
+            if args.format == "json":
+                print(render_json(findings, tools))
+            else:
+                print(render_markdown(findings, tools))
+            return 0
+
         md_path, json_path = write_reports(config, findings, tools)
         summary = summarize_scan(findings, tools)
         total = sum(item.size_bytes for item in findings)

--- a/src/mac_care/history.py
+++ b/src/mac_care/history.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+import json
+from pathlib import Path
+from typing import Any
+
+from .model import format_bytes
+from .summary import RISK_ORDER
+
+
+@dataclass(frozen=True)
+class ReportHistoryEntry:
+    generated_at: str
+    json_path: Path
+    markdown_path: Path | None
+    html_path: Path | None
+    risk_sizes: dict[str, int]
+    risk_counts: dict[str, int]
+    tool_warning_count: int
+
+
+def load_history(reports_dir: Path) -> list[ReportHistoryEntry]:
+    entries: list[ReportHistoryEntry] = []
+    for json_path in sorted(reports_dir.glob("mac-care-*.json"), reverse=True):
+        entry = _load_history_entry(json_path)
+        if entry:
+            entries.append(entry)
+    return entries
+
+
+def render_history_index(reports_dir: Path) -> str:
+    entries = load_history(reports_dir)
+    rows = "\n".join(_history_row(entry) for entry in entries)
+    latest_link = '<a href="latest.html">Open latest dashboard</a>' if (reports_dir / "latest.html").exists() else "No latest dashboard yet."
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mac Care Report History</title>
+  <style>
+    :root {{
+      color-scheme: light dark;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: Canvas;
+      color: CanvasText;
+    }}
+    body {{ margin: 0; padding: 32px; }}
+    main {{ max-width: 1180px; margin: 0 auto; }}
+    table {{ border-collapse: collapse; width: 100%; font-size: 0.92rem; margin-top: 20px; }}
+    th, td {{ border-bottom: 1px solid color-mix(in srgb, CanvasText 14%, transparent); padding: 9px 8px; text-align: left; }}
+    th {{ color: color-mix(in srgb, CanvasText 70%, transparent); font-weight: 600; }}
+    .size {{ text-align: right; white-space: nowrap; }}
+  </style>
+</head>
+<body>
+<main>
+  <h1>Mac Care Report History</h1>
+  <p>{latest_link}</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Generated</th>
+        <th class="size">Auto-safe</th>
+        <th class="size">Review</th>
+        <th class="size">Protected</th>
+        <th>Tool warnings</th>
+        <th>Reports</th>
+      </tr>
+    </thead>
+    <tbody>{rows or '<tr><td colspan="6">No reports found.</td></tr>'}</tbody>
+  </table>
+</main>
+</body>
+</html>
+"""
+
+
+def write_history_index(reports_dir: Path) -> Path:
+    path = reports_dir / "index.html"
+    path.write_text(render_history_index(reports_dir), encoding="utf-8")
+    return path
+
+
+def _load_history_entry(json_path: Path) -> ReportHistoryEntry | None:
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return None
+    risks = summary.get("risks")
+    if not isinstance(risks, dict):
+        return None
+
+    risk_sizes: dict[str, int] = {}
+    risk_counts: dict[str, int] = {}
+    for risk in RISK_ORDER:
+        risk_payload = risks.get(risk, {})
+        if not isinstance(risk_payload, dict):
+            risk_payload = {}
+        risk_sizes[risk] = int(risk_payload.get("size_bytes", 0) or 0)
+        risk_counts[risk] = int(risk_payload.get("count", 0) or 0)
+
+    stem = json_path.stem
+    md_path = json_path.with_suffix(".md")
+    return ReportHistoryEntry(
+        generated_at=str(payload.get("generated_at", stem.removeprefix("mac-care-"))),
+        json_path=json_path,
+        markdown_path=md_path if md_path.exists() else None,
+        html_path=json_path.parent / "latest.html" if (json_path.parent / "latest.html").exists() else None,
+        risk_sizes=risk_sizes,
+        risk_counts=risk_counts,
+        tool_warning_count=int(summary.get("tool_warning_count", 0) or 0),
+    )
+
+
+def _history_row(entry: ReportHistoryEntry) -> str:
+    report_links = [
+        f'<a href="{escape(entry.json_path.name)}">JSON</a>',
+    ]
+    if entry.markdown_path:
+        report_links.append(f'<a href="{escape(entry.markdown_path.name)}">Markdown</a>')
+    if entry.html_path:
+        report_links.append(f'<a href="{escape(entry.html_path.name)}">Dashboard</a>')
+
+    return (
+        "<tr>"
+        f"<td>{escape(entry.generated_at)}</td>"
+        f"<td class=\"size\">{_risk_cell(entry, 'auto_safe')}</td>"
+        f"<td class=\"size\">{_risk_cell(entry, 'review')}</td>"
+        f"<td class=\"size\">{_risk_cell(entry, 'protected')}</td>"
+        f"<td>{entry.tool_warning_count}</td>"
+        f"<td>{' | '.join(report_links)}</td>"
+        "</tr>"
+    )
+
+
+def _risk_cell(entry: ReportHistoryEntry, risk: str) -> str:
+    count = entry.risk_counts.get(risk, 0)
+    size = format_bytes(entry.risk_sizes.get(risk, 0))
+    return f"{escape(size)} ({count})"

--- a/src/mac_care/ids.py
+++ b/src/mac_care/ids.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import hashlib
+
+from .model import Finding
+
+
+def finding_id(finding: Finding) -> str:
+    payload = "\0".join(
+        [
+            finding.category,
+            finding.path,
+            finding.risk,
+            finding.source,
+            finding.reason,
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]

--- a/src/mac_care/notification.py
+++ b/src/mac_care/notification.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import subprocess
+
+from .model import format_bytes
+from .summary import ScanSummary
+
+
+def notification_text(summary: ScanSummary) -> str:
+    auto_safe = summary.risks["auto_safe"]
+    review = summary.risks["review"]
+    protected = summary.risks["protected"]
+    return (
+        f"{format_bytes(auto_safe.size_bytes)} auto-safe, "
+        f"{format_bytes(review.size_bytes)} review, "
+        f"{protected.count} protected, "
+        f"{summary.tool_warning_count} tool warnings"
+    )
+
+
+def notify_scan_complete(summary: ScanSummary) -> bool:
+    message = notification_text(summary)
+    script = f'display notification "{_escape_osascript(message)}" with title "Mac Care scan complete"'
+    try:
+        result = subprocess.run(["osascript", "-e", script], check=False, capture_output=True, text=True, timeout=8)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _escape_osascript(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/mac_care/report.py
+++ b/src/mac_care/report.py
@@ -8,20 +8,27 @@ from .model import Finding, ToolStatus, format_bytes
 from .summary import RISK_ORDER, summarize_scan
 
 
+def report_payload(findings: list[Finding], tools: list[ToolStatus]) -> dict:
+    summary = summarize_scan(findings, tools)
+    return {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "summary": summary.to_dict(),
+        "findings": [finding.__dict__ for finding in findings],
+        "tools": [tool.__dict__ for tool in tools],
+    }
+
+
+def render_json(findings: list[Finding], tools: list[ToolStatus]) -> str:
+    return json.dumps(report_payload(findings, tools), indent=2)
+
+
 def write_reports(config: Config, findings: list[Finding], tools: list[ToolStatus]) -> tuple[str, str]:
     config.ensure_dirs()
     stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
     json_path = config.reports_dir / f"mac-care-{stamp}.json"
     md_path = config.reports_dir / f"mac-care-{stamp}.md"
 
-    summary = summarize_scan(findings, tools)
-    payload = {
-        "generated_at": datetime.now().isoformat(timespec="seconds"),
-        "summary": summary.to_dict(),
-        "findings": [finding.__dict__ for finding in findings],
-        "tools": [tool.__dict__ for tool in tools],
-    }
-    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    json_path.write_text(render_json(findings, tools), encoding="utf-8")
     md_path.write_text(render_markdown(findings, tools), encoding="utf-8")
     return str(md_path), str(json_path)
 

--- a/src/mac_care/report.py
+++ b/src/mac_care/report.py
@@ -5,6 +5,7 @@ from html import escape
 import json
 
 from .config import Config
+from .history import write_history_index
 from .model import Finding, ToolStatus, format_bytes
 from .summary import RISK_ORDER, summarize_scan
 
@@ -33,6 +34,7 @@ def write_reports(config: Config, findings: list[Finding], tools: list[ToolStatu
     json_path.write_text(render_json(findings, tools), encoding="utf-8")
     md_path.write_text(render_markdown(findings, tools), encoding="utf-8")
     html_path.write_text(render_html(findings, tools), encoding="utf-8")
+    write_history_index(config.reports_dir)
     return str(md_path), str(json_path), str(html_path)
 
 

--- a/src/mac_care/report.py
+++ b/src/mac_care/report.py
@@ -5,6 +5,7 @@ import json
 
 from .config import Config
 from .model import Finding, ToolStatus, format_bytes
+from .summary import RISK_ORDER, summarize_scan
 
 
 def write_reports(config: Config, findings: list[Finding], tools: list[ToolStatus]) -> tuple[str, str]:
@@ -13,8 +14,10 @@ def write_reports(config: Config, findings: list[Finding], tools: list[ToolStatu
     json_path = config.reports_dir / f"mac-care-{stamp}.json"
     md_path = config.reports_dir / f"mac-care-{stamp}.md"
 
+    summary = summarize_scan(findings, tools)
     payload = {
         "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "summary": summary.to_dict(),
         "findings": [finding.__dict__ for finding in findings],
         "tools": [tool.__dict__ for tool in tools],
     }
@@ -24,8 +27,21 @@ def write_reports(config: Config, findings: list[Finding], tools: list[ToolStatu
 
 
 def render_markdown(findings: list[Finding], tools: list[ToolStatus]) -> str:
-    lines = ["# Mac Care Report", ""]
-    for risk in ["auto_safe", "review", "protected"]:
+    summary = summarize_scan(findings, tools)
+    lines = ["# Mac Care Report", "", "## Summary", ""]
+    lines.extend(["| Risk | Count | Size |", "| --- | ---: | ---: |"])
+    for risk in RISK_ORDER:
+        risk_summary = summary.risks[risk]
+        lines.append(f"| {risk} | {risk_summary.count} | {format_bytes(risk_summary.size_bytes)} |")
+    lines.extend(["", f"Tool warnings: {summary.tool_warning_count}", ""])
+
+    if summary.top_findings:
+        lines.extend(["### Top Findings", "", "| Category | Risk | Size | Source |", "| --- | --- | ---: | --- |"])
+        for item in summary.top_findings:
+            lines.append(f"| {item.category} | {item.risk} | {format_bytes(item.size_bytes)} | {item.source} |")
+        lines.append("")
+
+    for risk in RISK_ORDER:
         group = [item for item in findings if item.risk == risk]
         total = sum(item.size_bytes for item in group)
         lines.extend([f"## {risk}", "", f"Total: {format_bytes(total)}", ""])

--- a/src/mac_care/report.py
+++ b/src/mac_care/report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from html import escape
 import json
 
 from .config import Config
@@ -22,15 +23,17 @@ def render_json(findings: list[Finding], tools: list[ToolStatus]) -> str:
     return json.dumps(report_payload(findings, tools), indent=2)
 
 
-def write_reports(config: Config, findings: list[Finding], tools: list[ToolStatus]) -> tuple[str, str]:
+def write_reports(config: Config, findings: list[Finding], tools: list[ToolStatus]) -> tuple[str, str, str]:
     config.ensure_dirs()
     stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
     json_path = config.reports_dir / f"mac-care-{stamp}.json"
     md_path = config.reports_dir / f"mac-care-{stamp}.md"
+    html_path = config.reports_dir / "latest.html"
 
     json_path.write_text(render_json(findings, tools), encoding="utf-8")
     md_path.write_text(render_markdown(findings, tools), encoding="utf-8")
-    return str(md_path), str(json_path)
+    html_path.write_text(render_html(findings, tools), encoding="utf-8")
+    return str(md_path), str(json_path), str(html_path)
 
 
 def render_markdown(findings: list[Finding], tools: list[ToolStatus]) -> str:
@@ -65,3 +68,125 @@ def render_markdown(findings: list[Finding], tools: list[ToolStatus]) -> str:
         lines.append(f"| {tool.name} | {tool.status} | `{tool.detail}` |")
     lines.append("")
     return "\n".join(lines)
+
+
+def render_html(findings: list[Finding], tools: list[ToolStatus]) -> str:
+    summary = summarize_scan(findings, tools)
+    risk_cards = "\n".join(
+        _risk_card(risk, summary.risks[risk].count, summary.risks[risk].size_bytes) for risk in RISK_ORDER
+    )
+    top_findings = _finding_rows(summary.top_findings, include_risk=True)
+    risk_sections = "\n".join(_risk_section(risk, findings) for risk in RISK_ORDER)
+    tool_rows = "\n".join(
+        "<tr>"
+        f"<td>{escape(tool.name)}</td>"
+        f"<td><span class=\"status\">{escape(tool.status)}</span></td>"
+        f"<td><code>{escape(tool.detail)}</code></td>"
+        "</tr>"
+        for tool in tools
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mac Care Report</title>
+  <style>
+    :root {{
+      color-scheme: light dark;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: Canvas;
+      color: CanvasText;
+    }}
+    body {{ margin: 0; padding: 32px; }}
+    main {{ max-width: 1180px; margin: 0 auto; }}
+    h1, h2, h3 {{ margin: 0 0 12px; }}
+    section {{ margin-top: 32px; }}
+    .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }}
+    .card {{ border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 8px; padding: 14px; }}
+    .label {{ color: color-mix(in srgb, CanvasText 62%, transparent); font-size: 0.86rem; }}
+    .value {{ font-size: 1.5rem; font-weight: 650; margin-top: 4px; }}
+    table {{ border-collapse: collapse; width: 100%; font-size: 0.92rem; }}
+    th, td {{ border-bottom: 1px solid color-mix(in srgb, CanvasText 14%, transparent); padding: 9px 8px; text-align: left; vertical-align: top; }}
+    th {{ color: color-mix(in srgb, CanvasText 70%, transparent); font-weight: 600; }}
+    code {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }}
+    .size {{ text-align: right; white-space: nowrap; }}
+    .status {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }}
+  </style>
+</head>
+<body>
+<main>
+  <h1>Mac Care Report</h1>
+
+  <section>
+    <h2>Summary</h2>
+    <div class="cards">
+      {risk_cards}
+      <div class="card"><div class="label">Tool warnings</div><div class="value">{summary.tool_warning_count}</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Top Findings</h2>
+    <table>
+      <thead><tr><th>Category</th><th>Risk</th><th class="size">Size</th><th>Source</th><th>Path</th></tr></thead>
+      <tbody>{top_findings or '<tr><td colspan="5">No findings.</td></tr>'}</tbody>
+    </table>
+  </section>
+
+  {risk_sections}
+
+  <section>
+    <h2>Doctor</h2>
+    <table>
+      <thead><tr><th>Tool</th><th>Status</th><th>Detail</th></tr></thead>
+      <tbody>{tool_rows or '<tr><td colspan="3">No tool statuses.</td></tr>'}</tbody>
+    </table>
+  </section>
+</main>
+</body>
+</html>
+"""
+
+
+def _risk_card(risk: str, count: int, size_bytes: int) -> str:
+    return (
+        "<div class=\"card\">"
+        f"<div class=\"label\">{escape(risk)}</div>"
+        f"<div class=\"value\">{format_bytes(size_bytes)}</div>"
+        f"<div class=\"label\">{count} findings</div>"
+        "</div>"
+    )
+
+
+def _risk_section(risk: str, findings: list[Finding]) -> str:
+    group = [finding for finding in findings if finding.risk == risk]
+    rows = _finding_rows(group) or '<tr><td colspan="5">No items.</td></tr>'
+    return (
+        "<section>"
+        f"<h2>{escape(risk)}</h2>"
+        "<table>"
+        "<thead><tr><th>Category</th><th class=\"size\">Size</th><th>Source</th><th>Path</th><th>Reason</th></tr></thead>"
+        f"<tbody>{rows}</tbody>"
+        "</table>"
+        "</section>"
+    )
+
+
+def _finding_rows(findings: list[Finding], include_risk: bool = False) -> str:
+    rows: list[str] = []
+    for finding in sorted(findings, key=lambda item: item.size_bytes, reverse=True):
+        risk_cell = f"<td>{escape(finding.risk)}</td>" if include_risk else ""
+        reason_cell = "" if include_risk else f"<td>{escape(finding.reason)}</td>"
+        rows.append(
+            "<tr>"
+            f"<td>{escape(finding.category)}</td>"
+            f"{risk_cell}"
+            f"<td class=\"size\">{format_bytes(finding.size_bytes)}</td>"
+            f"<td>{escape(finding.source)}</td>"
+            f"<td><code>{escape(finding.path)}</code></td>"
+            f"{reason_cell}"
+            "</tr>"
+        )
+    return "\n".join(rows)

--- a/src/mac_care/report.py
+++ b/src/mac_care/report.py
@@ -6,6 +6,7 @@ import json
 
 from .config import Config
 from .history import write_history_index
+from .ids import finding_id
 from .model import Finding, ToolStatus, format_bytes
 from .summary import RISK_ORDER, summarize_scan
 
@@ -15,7 +16,7 @@ def report_payload(findings: list[Finding], tools: list[ToolStatus]) -> dict:
     return {
         "generated_at": datetime.now().isoformat(timespec="seconds"),
         "summary": summary.to_dict(),
-        "findings": [finding.__dict__ for finding in findings],
+        "findings": [_finding_payload(finding) for finding in findings],
         "tools": [tool.__dict__ for tool in tools],
     }
 
@@ -192,3 +193,9 @@ def _finding_rows(findings: list[Finding], include_risk: bool = False) -> str:
             "</tr>"
         )
     return "\n".join(rows)
+
+
+def _finding_payload(finding: Finding) -> dict:
+    payload = finding.__dict__.copy()
+    payload["id"] = finding_id(finding)
+    return payload

--- a/src/mac_care/review.py
+++ b/src/mac_care/review.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .clean import quarantine_finding
+from .config import Config
+from .ids import finding_id
+from .model import Finding
+
+
+def approve_finding(report_path: Path, finding_id_value: str, config: Config, dry_run: bool = True) -> str:
+    finding = _finding_from_report(report_path, finding_id_value)
+    if finding is None:
+        return f"skipped review approval: finding {finding_id_value} was not found in {report_path}"
+
+    if finding.risk == "protected":
+        return f"skipped review approval for {finding_id_value}: protected findings cannot be actioned"
+    if finding.risk != "review":
+        return f"skipped review approval for {finding_id_value}: finding risk is {finding.risk}, not review"
+
+    if dry_run:
+        return f"would quarantine review finding {finding_id_value}: {finding.path}"
+
+    return quarantine_finding(finding, config)
+
+
+def _finding_from_report(report_path: Path, finding_id_value: str) -> Finding | None:
+    try:
+        payload = json.loads(report_path.expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    findings = payload.get("findings", [])
+    if not isinstance(findings, list):
+        return None
+
+    for item in findings:
+        if not isinstance(item, dict):
+            continue
+        finding = _finding_from_payload(item)
+        if not finding:
+            continue
+        item_id = str(item.get("id") or finding_id(finding))
+        if item_id == finding_id_value:
+            return finding
+    return None
+
+
+def _finding_from_payload(payload: dict) -> Finding | None:
+    required = ["category", "path", "size_bytes", "risk", "reason"]
+    if any(key not in payload for key in required):
+        return None
+    risk = str(payload["risk"])
+    if risk not in {"auto_safe", "review", "protected"}:
+        return None
+    return Finding(
+        category=str(payload["category"]),
+        path=str(payload["path"]),
+        size_bytes=int(payload.get("size_bytes") or 0),
+        risk=risk,  # type: ignore[arg-type]
+        reason=str(payload["reason"]),
+        source=str(payload.get("source") or "native"),
+    )

--- a/src/mac_care/scheduler.py
+++ b/src/mac_care/scheduler.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import plistlib
+import shutil
+import subprocess
+import sys
+
+from .config import Config
+
+
+LABEL = "com.mac-care.periodic"
+PLIST_PATH = Path("~/Library/LaunchAgents/com.mac-care.periodic.plist").expanduser()
+
+
+@dataclass(frozen=True)
+class ScheduleResult:
+    plist_path: Path
+    message: str
+
+
+def default_program_arguments() -> list[str]:
+    executable = shutil.which("mac-care")
+    if executable:
+        return [executable, "scan"]
+    return [sys.executable, "-m", "mac_care.cli", "scan"]
+
+
+def build_plist(config: Config, interval_hours: int = 24, program_arguments: list[str] | None = None) -> dict:
+    interval_seconds = max(1, interval_hours) * 3600
+    logs_dir = config.reports_dir.parent / "logs"
+    return {
+        "Label": LABEL,
+        "ProgramArguments": program_arguments or default_program_arguments(),
+        "StartInterval": interval_seconds,
+        "RunAtLoad": False,
+        "StandardOutPath": str(logs_dir / "mac-care-schedule.out.log"),
+        "StandardErrorPath": str(logs_dir / "mac-care-schedule.err.log"),
+        "EnvironmentVariables": {
+            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        },
+    }
+
+
+def render_plist(config: Config, interval_hours: int = 24, program_arguments: list[str] | None = None) -> str:
+    payload = build_plist(config, interval_hours=interval_hours, program_arguments=program_arguments)
+    return plistlib.dumps(payload, sort_keys=True).decode("utf-8")
+
+
+def install_schedule(config: Config, interval_hours: int = 24, dry_run: bool = True) -> ScheduleResult:
+    plist_text = render_plist(config, interval_hours=interval_hours)
+    if dry_run:
+        return ScheduleResult(PLIST_PATH, plist_text)
+
+    config.ensure_dirs()
+    (config.reports_dir.parent / "logs").mkdir(parents=True, exist_ok=True)
+    PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PLIST_PATH.write_text(plist_text, encoding="utf-8")
+    return ScheduleResult(PLIST_PATH, f"Installed schedule at {PLIST_PATH}")
+
+
+def uninstall_schedule(dry_run: bool = True) -> ScheduleResult:
+    if dry_run:
+        return ScheduleResult(PLIST_PATH, f"Would unload and remove {PLIST_PATH}")
+
+    _launchctl_unload(PLIST_PATH)
+    if PLIST_PATH.exists():
+        PLIST_PATH.unlink()
+        return ScheduleResult(PLIST_PATH, f"Removed schedule at {PLIST_PATH}")
+    return ScheduleResult(PLIST_PATH, f"No schedule found at {PLIST_PATH}")
+
+
+def _launchctl_unload(plist_path: Path) -> None:
+    if not plist_path.exists() or not shutil.which("launchctl"):
+        return
+    subprocess.run(["launchctl", "unload", str(plist_path)], check=False, capture_output=True, text=True, timeout=10)

--- a/src/mac_care/scheduler.py
+++ b/src/mac_care/scheduler.py
@@ -23,8 +23,8 @@ class ScheduleResult:
 def default_program_arguments() -> list[str]:
     executable = shutil.which("mac-care")
     if executable:
-        return [executable, "scan"]
-    return [sys.executable, "-m", "mac_care.cli", "scan"]
+        return [executable, "scan", "--notify"]
+    return [sys.executable, "-m", "mac_care.cli", "scan", "--notify"]
 
 
 def build_plist(config: Config, interval_hours: int = 24, program_arguments: list[str] | None = None) -> dict:

--- a/src/mac_care/summary.py
+++ b/src/mac_care/summary.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from .model import Finding, Risk, ToolStatus
+
+
+RISK_ORDER: tuple[Risk, ...] = ("auto_safe", "review", "protected")
+WARNING_STATUSES = {"missing", "review", "optional_missing"}
+
+
+@dataclass(frozen=True)
+class RiskSummary:
+    count: int
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class ScanSummary:
+    risks: dict[Risk, RiskSummary]
+    top_findings: list[Finding]
+    tool_warning_count: int
+
+    def to_dict(self) -> dict:
+        return {
+            "risks": {risk: asdict(summary) for risk, summary in self.risks.items()},
+            "top_findings": [asdict(finding) for finding in self.top_findings],
+            "tool_warning_count": self.tool_warning_count,
+        }
+
+
+def summarize_scan(findings: list[Finding], tools: list[ToolStatus], top_n: int = 5) -> ScanSummary:
+    risks: dict[Risk, RiskSummary] = {}
+    for risk in RISK_ORDER:
+        group = [finding for finding in findings if finding.risk == risk]
+        risks[risk] = RiskSummary(
+            count=len(group),
+            size_bytes=sum(finding.size_bytes for finding in group),
+        )
+
+    top_findings = sorted(findings, key=lambda finding: finding.size_bytes, reverse=True)[:top_n]
+    tool_warning_count = sum(1 for tool in tools if tool.status in WARNING_STATUSES)
+    return ScanSummary(risks=risks, top_findings=top_findings, tool_warning_count=tool_warning_count)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,99 @@
+import json
+
+from mac_care.clean import safe_clean
+from mac_care.config import Config
+from mac_care.model import Finding
+
+
+def test_safe_clean_dry_run_does_not_move(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    actions = safe_clean(
+        [Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")],
+        config=config,
+        dry_run=True,
+    )
+
+    assert actions == [f"would clean brew_cache: {target}"]
+    assert target.exists()
+    assert not config.quarantine_dir.exists()
+
+
+def test_safe_clean_quarantines_executable_auto_safe_finding(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    actions = safe_clean(
+        [Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")],
+        config=config,
+        dry_run=False,
+    )
+
+    assert actions[0].startswith("quarantined brew_cache:")
+    assert not target.exists()
+    moved = list(config.quarantine_dir.glob("*/brew_cache/cache-item"))
+    assert len(moved) == 1
+    metadata_files = list(config.quarantine_dir.glob("*/brew_cache/cache-item.metadata.json"))
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["original_path"] == str(target)
+    assert metadata["quarantine_path"] == str(moved[0])
+
+
+def test_safe_clean_skips_review_and_protected_findings(tmp_path):
+    review = tmp_path / "review"
+    protected = tmp_path / "protected"
+    review.write_text("review", encoding="utf-8")
+    protected.write_text("protected", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    actions = safe_clean(
+        [
+            Finding("brew_cache", str(review), 1, "review", "needs review", "brew"),
+            Finding("brew_cache", str(protected), 1, "protected", "protected", "brew"),
+        ],
+        config=config,
+        dry_run=False,
+    )
+
+    assert actions == []
+    assert review.exists()
+    assert protected.exists()
+
+
+def test_safe_clean_rechecks_protected_paths(tmp_path):
+    protected_root = tmp_path / "protected"
+    target = protected_root / "cache-item"
+    protected_root.mkdir()
+    target.write_text("cache", encoding="utf-8")
+    config = Config(
+        reports_dir=tmp_path / "reports",
+        quarantine_dir=tmp_path / "quarantine",
+        protected_paths=[protected_root],
+    )
+
+    actions = safe_clean(
+        [Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")],
+        config=config,
+        dry_run=False,
+    )
+
+    assert actions == [f"skipped execution for brew_cache: protected path {target}"]
+    assert target.exists()
+
+
+def test_safe_clean_skips_non_itemized_auto_safe_categories(tmp_path):
+    target = tmp_path / "Caches"
+    target.mkdir()
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    actions = safe_clean(
+        [Finding("user_caches", str(target), 5, "auto_safe", "broad cache directory")],
+        config=config,
+        dry_run=False,
+    )
+
+    assert actions == ["skipped execution for user_caches: category is not itemized for quarantine yet"]
+    assert target.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,3 +83,18 @@ def test_schedule_uninstall_dry_run(monkeypatch, capsys):
     assert cli.main() == 0
 
     assert "Would unload" in capsys.readouterr().out
+
+
+def test_review_approve_dry_run(monkeypatch, capsys):
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(cli, "approve_finding", lambda *_args, **_kwargs: "would quarantine review finding abc: /tmp/item")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["mac-care", "review", "approve", "--report", "/tmp/report.json", "--finding-id", "abc"],
+    )
+
+    assert cli.main() == 0
+
+    output = capsys.readouterr().out
+    assert "would quarantine review finding abc" in output
+    assert "Dry run only" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def test_scan_default_writes_reports(monkeypatch, capsys):
     monkeypatch.setattr(cli.Config, "load", lambda _: object())
     monkeypatch.setattr(cli, "scan", lambda _: [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs")])
     monkeypatch.setattr(cli, "check_tools", lambda: [ToolStatus("git", "ok", "/usr/bin/git")])
-    monkeypatch.setattr(cli, "write_reports", lambda *_: ("/tmp/report.md", "/tmp/report.json"))
+    monkeypatch.setattr(cli, "write_reports", lambda *_: ("/tmp/report.md", "/tmp/report.json", "/tmp/latest.html"))
     monkeypatch.setattr("sys.argv", ["mac-care", "scan"])
 
     assert cli.main() == 0
@@ -44,3 +44,4 @@ def test_scan_default_writes_reports(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "Scanned 1 findings" in output
     assert "Markdown report: /tmp/report.md" in output
+    assert "HTML report: /tmp/latest.html" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,20 @@ def test_scan_default_writes_reports(monkeypatch, capsys):
     assert "HTML report: /tmp/latest.html" in output
 
 
+def test_scan_notify_posts_notification(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(cli, "scan", lambda _: [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs")])
+    monkeypatch.setattr(cli, "check_tools", lambda: [ToolStatus("git", "ok", "/usr/bin/git")])
+    monkeypatch.setattr(cli, "write_reports", lambda *_: ("/tmp/report.md", "/tmp/report.json", "/tmp/latest.html"))
+    monkeypatch.setattr(cli, "notify_scan_complete", lambda summary: calls.append(summary) or True)
+    monkeypatch.setattr("sys.argv", ["mac-care", "scan", "--notify"])
+
+    assert cli.main() == 0
+
+    assert len(calls) == 1
+
+
 def test_schedule_install_dry_run(monkeypatch, capsys):
     monkeypatch.setattr(cli.Config, "load", lambda _: object())
     monkeypatch.setattr(cli, "install_schedule", lambda *_args, **_kwargs: type("Result", (), {"message": "<plist/>"})())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,3 +45,27 @@ def test_scan_default_writes_reports(monkeypatch, capsys):
     assert "Scanned 1 findings" in output
     assert "Markdown report: /tmp/report.md" in output
     assert "HTML report: /tmp/latest.html" in output
+
+
+def test_schedule_install_dry_run(monkeypatch, capsys):
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(cli, "install_schedule", lambda *_args, **_kwargs: type("Result", (), {"message": "<plist/>"})())
+    monkeypatch.setattr("sys.argv", ["mac-care", "schedule", "install", "--dry-run"])
+
+    assert cli.main() == 0
+
+    assert "<plist/>" in capsys.readouterr().out
+
+
+def test_schedule_uninstall_dry_run(monkeypatch, capsys):
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(
+        cli,
+        "uninstall_schedule",
+        lambda **_kwargs: type("Result", (), {"message": "Would unload and remove plist"})(),
+    )
+    monkeypatch.setattr("sys.argv", ["mac-care", "schedule", "uninstall", "--dry-run"])
+
+    assert cli.main() == 0
+
+    assert "Would unload" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+
+from mac_care import cli
+from mac_care.model import Finding, ToolStatus
+
+
+def test_scan_stdout_json(monkeypatch, capsys):
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(cli, "scan", lambda _: [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs")])
+    monkeypatch.setattr(cli, "check_tools", lambda: [ToolStatus("git", "ok", "/usr/bin/git")])
+    monkeypatch.setattr("sys.argv", ["mac-care", "scan", "--stdout", "--format", "json"])
+
+    assert cli.main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["risks"]["auto_safe"]["count"] == 1
+    assert payload["findings"][0]["category"] == "logs"
+
+
+def test_scan_stdout_markdown(monkeypatch, capsys):
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(cli, "scan", lambda _: [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs")])
+    monkeypatch.setattr(cli, "check_tools", lambda: [ToolStatus("git", "ok", "/usr/bin/git")])
+    monkeypatch.setattr("sys.argv", ["mac-care", "scan", "--stdout", "--format", "markdown"])
+
+    assert cli.main() == 0
+
+    output = capsys.readouterr().out
+    assert "# Mac Care Report" in output
+    assert "| auto_safe | 1 | 100.0 B |" in output
+
+
+def test_scan_default_writes_reports(monkeypatch, capsys):
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(cli, "scan", lambda _: [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs")])
+    monkeypatch.setattr(cli, "check_tools", lambda: [ToolStatus("git", "ok", "/usr/bin/git")])
+    monkeypatch.setattr(cli, "write_reports", lambda *_: ("/tmp/report.md", "/tmp/report.json"))
+    monkeypatch.setattr("sys.argv", ["mac-care", "scan"])
+
+    assert cli.main() == 0
+
+    output = capsys.readouterr().out
+    assert "Scanned 1 findings" in output
+    assert "Markdown report: /tmp/report.md" in output

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,60 @@
+import json
+
+from mac_care.history import load_history, render_history_index, write_history_index
+
+
+def _write_report(path, generated_at="2026-05-02T21:08:26", auto_safe_size=1024):
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": generated_at,
+                "summary": {
+                    "risks": {
+                        "auto_safe": {"count": 1, "size_bytes": auto_safe_size},
+                        "review": {"count": 2, "size_bytes": 2048},
+                        "protected": {"count": 0, "size_bytes": 0},
+                    },
+                    "top_findings": [],
+                    "tool_warning_count": 3,
+                },
+                "findings": [],
+                "tools": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_history_skips_malformed_reports(tmp_path):
+    _write_report(tmp_path / "mac-care-2026-05-02-210000.json")
+    (tmp_path / "mac-care-bad.json").write_text("{not json", encoding="utf-8")
+
+    entries = load_history(tmp_path)
+
+    assert len(entries) == 1
+    assert entries[0].risk_counts["auto_safe"] == 1
+    assert entries[0].tool_warning_count == 3
+
+
+def test_render_history_index_links_latest_and_reports(tmp_path):
+    _write_report(tmp_path / "mac-care-2026-05-02-210000.json")
+    (tmp_path / "mac-care-2026-05-02-210000.md").write_text("# Report", encoding="utf-8")
+    (tmp_path / "latest.html").write_text("<html></html>", encoding="utf-8")
+
+    output = render_history_index(tmp_path)
+
+    assert "Mac Care Report History" in output
+    assert "Open latest dashboard" in output
+    assert "mac-care-2026-05-02-210000.json" in output
+    assert "mac-care-2026-05-02-210000.md" in output
+    assert "1.0 KB (1)" in output
+
+
+def test_write_history_index_creates_index(tmp_path):
+    _write_report(tmp_path / "mac-care-2026-05-02-210000.json")
+
+    path = write_history_index(tmp_path)
+
+    assert path == tmp_path / "index.html"
+    assert path.exists()
+    assert "Mac Care Report History" in path.read_text(encoding="utf-8")

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,16 @@
+from mac_care.ids import finding_id
+from mac_care.model import Finding
+
+
+def test_finding_id_is_stable_for_same_finding():
+    finding = Finding("logs", "/tmp/logs", 1, "review", "reason", "native")
+
+    assert finding_id(finding) == finding_id(finding)
+    assert len(finding_id(finding)) == 16
+
+
+def test_finding_id_changes_for_path():
+    first = Finding("logs", "/tmp/logs", 1, "review", "reason", "native")
+    second = Finding("logs", "/tmp/other", 1, "review", "reason", "native")
+
+    assert finding_id(first) != finding_id(second)

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,47 @@
+import subprocess
+
+from mac_care.model import Finding, ToolStatus
+from mac_care.notification import notification_text, notify_scan_complete
+from mac_care.summary import summarize_scan
+
+
+def _summary():
+    return summarize_scan(
+        [
+            Finding("logs", "/tmp/logs", 1024, "auto_safe", "old logs"),
+            Finding("docker", "/tmp/docker", 2048, "review", "docker waste", "docker"),
+            Finding("codex", "/tmp/codex", 0, "protected", "dirty repo"),
+        ],
+        [ToolStatus("docker", "review", "daemon unavailable")],
+    )
+
+
+def test_notification_text_summarizes_scan():
+    text = notification_text(_summary())
+
+    assert "1.0 KB auto-safe" in text
+    assert "2.0 KB review" in text
+    assert "1 protected" in text
+    assert "1 tool warnings" in text
+
+
+def test_notify_scan_complete_returns_true_on_success(monkeypatch):
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr("mac_care.notification.subprocess.run", fake_run)
+
+    assert notify_scan_complete(_summary()) is True
+    assert calls[0][0][0][0] == "osascript"
+
+
+def test_notify_scan_complete_degrades_on_failure(monkeypatch):
+    def fake_run(*_args, **_kwargs):
+        raise OSError("missing osascript")
+
+    monkeypatch.setattr("mac_care.notification.subprocess.run", fake_run)
+
+    assert notify_scan_complete(_summary()) is False

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,10 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
+from mac_care.config import Config
 from mac_care.model import Finding, ToolStatus
-from mac_care.report import render_html, render_json, render_markdown
+from mac_care.report import render_html, render_json, render_markdown, write_reports
 
 
 class ReportTests(unittest.TestCase):
@@ -38,6 +41,19 @@ class ReportTests(unittest.TestCase):
         self.assertIn("Top Findings", output)
         self.assertIn("/tmp/&lt;logs&gt;", output)
         self.assertNotIn("<button", output)
+
+    def test_write_reports_creates_history_index(self) -> None:
+        with TemporaryDirectory() as directory:
+            reports_dir = Path(directory)
+            config = Config(reports_dir=reports_dir, quarantine_dir=reports_dir / "quarantine")
+
+            write_reports(
+                config,
+                [Finding("logs", "/tmp/logs", 1024, "auto_safe", "old logs")],
+                [ToolStatus("git", "ok", "/usr/bin/git")],
+            )
+
+            self.assertTrue((reports_dir / "index.html").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,7 @@
 import unittest
 
 from mac_care.model import Finding, ToolStatus
-from mac_care.report import render_json, render_markdown
+from mac_care.report import render_html, render_json, render_markdown
 
 
 class ReportTests(unittest.TestCase):
@@ -26,6 +26,18 @@ class ReportTests(unittest.TestCase):
 
         self.assertIn('"summary"', output)
         self.assertIn('"findings"', output)
+
+    def test_render_html_is_read_only_dashboard(self) -> None:
+        output = render_html(
+            [Finding("logs", "/tmp/<logs>", 1024, "auto_safe", "old logs")],
+            [ToolStatus("git", "ok", "/usr/bin/git")],
+        )
+
+        self.assertIn("<title>Mac Care Report</title>", output)
+        self.assertIn("Summary", output)
+        self.assertIn("Top Findings", output)
+        self.assertIn("/tmp/&lt;logs&gt;", output)
+        self.assertNotIn("<button", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,7 @@
 import unittest
 
 from mac_care.model import Finding, ToolStatus
-from mac_care.report import render_markdown
+from mac_care.report import render_json, render_markdown
 
 
 class ReportTests(unittest.TestCase):
@@ -17,6 +17,15 @@ class ReportTests(unittest.TestCase):
         self.assertIn("auto_safe", output)
         self.assertIn("logs", output)
         self.assertIn("git", output)
+
+    def test_render_json_includes_summary(self) -> None:
+        output = render_json(
+            [Finding("logs", "/tmp/logs", 1024, "auto_safe", "old logs")],
+            [ToolStatus("git", "ok", "/usr/bin/git")],
+        )
+
+        self.assertIn('"summary"', output)
+        self.assertIn('"findings"', output)
 
 
 if __name__ == "__main__":

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,6 +12,8 @@ class ReportTests(unittest.TestCase):
         )
 
         self.assertIn("# Mac Care Report", output)
+        self.assertIn("## Summary", output)
+        self.assertIn("Tool warnings", output)
         self.assertIn("auto_safe", output)
         self.assertIn("logs", output)
         self.assertIn("git", output)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -29,6 +29,7 @@ class ReportTests(unittest.TestCase):
 
         self.assertIn('"summary"', output)
         self.assertIn('"findings"', output)
+        self.assertIn('"id"', output)
 
     def test_render_html_is_read_only_dashboard(self) -> None:
         output = render_html(

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,69 @@
+import json
+
+from mac_care.config import Config
+from mac_care.ids import finding_id
+from mac_care.model import Finding
+from mac_care.review import approve_finding
+
+
+def _write_report(path, findings):
+    path.write_text(json.dumps({"findings": findings}), encoding="utf-8")
+
+
+def _payload(finding):
+    payload = finding.__dict__.copy()
+    payload["id"] = finding_id(finding)
+    return payload
+
+
+def test_approve_finding_dry_run(tmp_path):
+    target = tmp_path / "orphan"
+    target.write_text("data", encoding="utf-8")
+    finding = Finding("orphaned_app_files", str(target), 4, "review", "orphan", "pearcleaner")
+    report = tmp_path / "report.json"
+    _write_report(report, [_payload(finding)])
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    result = approve_finding(report, finding_id(finding), config, dry_run=True)
+
+    assert result == f"would quarantine review finding {finding_id(finding)}: {target}"
+    assert target.exists()
+
+
+def test_approve_finding_execute_quarantines_review_item(tmp_path):
+    target = tmp_path / "orphan"
+    target.write_text("data", encoding="utf-8")
+    finding = Finding("orphaned_app_files", str(target), 4, "review", "orphan", "pearcleaner")
+    report = tmp_path / "report.json"
+    _write_report(report, [_payload(finding)])
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    result = approve_finding(report, finding_id(finding), config, dry_run=False)
+
+    assert result.startswith("quarantined orphaned_app_files:")
+    assert not target.exists()
+    assert list(config.quarantine_dir.glob("*/orphaned_app_files/orphan"))
+
+
+def test_approve_finding_rejects_protected(tmp_path):
+    target = tmp_path / "protected"
+    target.write_text("data", encoding="utf-8")
+    finding = Finding("orphaned_app_files", str(target), 4, "protected", "protected", "pearcleaner")
+    report = tmp_path / "report.json"
+    _write_report(report, [_payload(finding)])
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    result = approve_finding(report, finding_id(finding), config, dry_run=False)
+
+    assert "protected findings cannot be actioned" in result
+    assert target.exists()
+
+
+def test_approve_finding_rejects_unknown_id(tmp_path):
+    report = tmp_path / "report.json"
+    _write_report(report, [])
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    result = approve_finding(report, "missing", config, dry_run=False)
+
+    assert "was not found" in result

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,11 +8,11 @@ from mac_care import scheduler
 def test_render_plist_runs_scan_only(tmp_path):
     config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
 
-    plist = scheduler.render_plist(config, interval_hours=6, program_arguments=["/bin/mac-care", "scan"])
+    plist = scheduler.render_plist(config, interval_hours=6, program_arguments=["/bin/mac-care", "scan", "--notify"])
     payload = plistlib.loads(plist.encode("utf-8"))
 
     assert payload["Label"] == scheduler.LABEL
-    assert payload["ProgramArguments"] == ["/bin/mac-care", "scan"]
+    assert payload["ProgramArguments"] == ["/bin/mac-care", "scan", "--notify"]
     assert payload["StartInterval"] == 21600
     assert "clean" not in payload["ProgramArguments"]
 
@@ -20,7 +20,7 @@ def test_render_plist_runs_scan_only(tmp_path):
 def test_install_schedule_dry_run_does_not_write(monkeypatch, tmp_path):
     plist_path = tmp_path / "com.mac-care.periodic.plist"
     monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
-    monkeypatch.setattr(scheduler, "default_program_arguments", lambda: ["/bin/mac-care", "scan"])
+    monkeypatch.setattr(scheduler, "default_program_arguments", lambda: ["/bin/mac-care", "scan", "--notify"])
     config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
 
     result = scheduler.install_schedule(config, interval_hours=12, dry_run=True)
@@ -33,7 +33,7 @@ def test_install_schedule_dry_run_does_not_write(monkeypatch, tmp_path):
 def test_install_schedule_writes_plist(monkeypatch, tmp_path):
     plist_path = tmp_path / "LaunchAgents" / "com.mac-care.periodic.plist"
     monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
-    monkeypatch.setattr(scheduler, "default_program_arguments", lambda: ["/bin/mac-care", "scan"])
+    monkeypatch.setattr(scheduler, "default_program_arguments", lambda: ["/bin/mac-care", "scan", "--notify"])
     config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
 
     result = scheduler.install_schedule(config, interval_hours=24, dry_run=False)
@@ -41,7 +41,7 @@ def test_install_schedule_writes_plist(monkeypatch, tmp_path):
     assert result.plist_path == plist_path
     assert plist_path.exists()
     payload = plistlib.loads(plist_path.read_bytes())
-    assert payload["ProgramArguments"] == ["/bin/mac-care", "scan"]
+    assert payload["ProgramArguments"] == ["/bin/mac-care", "scan", "--notify"]
 
 
 def test_uninstall_schedule_dry_run_does_not_remove(monkeypatch, tmp_path):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import plistlib
+
+from mac_care.config import Config
+from mac_care import scheduler
+
+
+def test_render_plist_runs_scan_only(tmp_path):
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    plist = scheduler.render_plist(config, interval_hours=6, program_arguments=["/bin/mac-care", "scan"])
+    payload = plistlib.loads(plist.encode("utf-8"))
+
+    assert payload["Label"] == scheduler.LABEL
+    assert payload["ProgramArguments"] == ["/bin/mac-care", "scan"]
+    assert payload["StartInterval"] == 21600
+    assert "clean" not in payload["ProgramArguments"]
+
+
+def test_install_schedule_dry_run_does_not_write(monkeypatch, tmp_path):
+    plist_path = tmp_path / "com.mac-care.periodic.plist"
+    monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
+    monkeypatch.setattr(scheduler, "default_program_arguments", lambda: ["/bin/mac-care", "scan"])
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    result = scheduler.install_schedule(config, interval_hours=12, dry_run=True)
+
+    assert result.plist_path == plist_path
+    assert "StartInterval" in result.message
+    assert not plist_path.exists()
+
+
+def test_install_schedule_writes_plist(monkeypatch, tmp_path):
+    plist_path = tmp_path / "LaunchAgents" / "com.mac-care.periodic.plist"
+    monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
+    monkeypatch.setattr(scheduler, "default_program_arguments", lambda: ["/bin/mac-care", "scan"])
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    result = scheduler.install_schedule(config, interval_hours=24, dry_run=False)
+
+    assert result.plist_path == plist_path
+    assert plist_path.exists()
+    payload = plistlib.loads(plist_path.read_bytes())
+    assert payload["ProgramArguments"] == ["/bin/mac-care", "scan"]
+
+
+def test_uninstall_schedule_dry_run_does_not_remove(monkeypatch, tmp_path):
+    plist_path = tmp_path / "com.mac-care.periodic.plist"
+    plist_path.write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
+
+    result = scheduler.uninstall_schedule(dry_run=True)
+
+    assert "Would unload and remove" in result.message
+    assert plist_path.exists()
+
+
+def test_uninstall_schedule_removes_existing_plist(monkeypatch, tmp_path):
+    plist_path = tmp_path / "com.mac-care.periodic.plist"
+    plist_path.write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
+    monkeypatch.setattr(scheduler, "_launchctl_unload", lambda _: None)
+
+    result = scheduler.uninstall_schedule(dry_run=False)
+
+    assert "Removed schedule" in result.message
+    assert not plist_path.exists()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,38 @@
+from mac_care.model import Finding, ToolStatus
+from mac_care.summary import summarize_scan
+
+
+def test_summarize_scan_groups_by_risk_and_size():
+    summary = summarize_scan(
+        [
+            Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs", "native"),
+            Finding("docker", "/var/lib/docker", 300, "review", "reclaimable", "docker"),
+            Finding("codex", "/tmp/codex", 200, "protected", "dirty repo", "native"),
+            Finding("brew", "/tmp/brew", 50, "auto_safe", "brew cleanup", "brew"),
+        ],
+        [
+            ToolStatus("git", "ok", "/usr/bin/git"),
+            ToolStatus("docker", "review", "daemon unavailable"),
+            ToolStatus("pearcleaner", "optional_missing", "not installed"),
+        ],
+        top_n=2,
+    )
+
+    assert summary.risks["auto_safe"].count == 2
+    assert summary.risks["auto_safe"].size_bytes == 150
+    assert summary.risks["review"].count == 1
+    assert summary.risks["protected"].size_bytes == 200
+    assert [finding.category for finding in summary.top_findings] == ["docker", "codex"]
+    assert summary.tool_warning_count == 2
+
+
+def test_summarize_scan_to_dict_is_json_ready():
+    summary = summarize_scan(
+        [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs", "native")],
+        [],
+    )
+
+    payload = summary.to_dict()
+
+    assert payload["risks"]["auto_safe"]["count"] == 1
+    assert payload["top_findings"][0]["category"] == "logs"


### PR DESCRIPTION
## Summary

Implements the report, schedule, notification, live validation, and first quarantine/review cleanup workflow for mac-care.

## What changed

- Added compact scan summaries with risk totals, top findings, and tool warning counts.
- Added `mac-care scan --stdout --format json|markdown`.
- Added static read-only HTML dashboard generation via `latest.html`.
- Added report history index generation via `index.html`.
- Added launchd schedule install/uninstall commands.
- Added `mac-care scan --notify` and wired scheduled scans to notify.
- Live-tested Pearcleaner cask/CLI and documented timeout behavior.
- Added dashboard action backend safety model doc.
- Added quarantine execution for eligible `auto_safe` findings.
- Added review approval by stable finding ID from JSON reports.

## Safety notes

- No direct deletion is implemented; execution moves files to quarantine only.
- Broad containers like caches, logs, Trash, and `/tmp` are skipped until scan itemizes their contents.
- Review approval accepts stable finding IDs from known reports, not arbitrary paths.
- Protected findings are rejected.
- Scheduled scans run scan/report/notify only, not cleanup.

## Validation

- `python -m pytest tests/ -q` -> 107 passed
- Live `mac-care scan` generated Markdown, JSON, HTML, and history index reports.
- `mac-care schedule install --dry-run` validated during implementation.
- GitNexus impact/check flow used before edits/commits where available.

Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
