### PR TITLE
docs(#42): comprehensive post-implementation documentation sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,18 +38,30 @@ Do not auto-delete these unless the user explicitly changes config:
 
 ## Architecture
 
-- `src/mac_care/cli.py`: command routing
+- `src/mac_care/cli.py`: command routing (10 commands)
 - `src/mac_care/scan.py`: scan-only cleanup findings
-- `src/mac_care/doctor.py`: developer tool and environment checks
+- `src/mac_care/doctor.py`: developer tool health checks (tools, SSH keys, redundant toolchains)
 - `src/mac_care/clean.py`: safe cleanup orchestration
-- `src/mac_care/report.py`: Markdown and JSON reports
+- `src/mac_care/report.py`: Markdown + JSON + HTML report writer; report rotation
+- `src/mac_care/model.py`: Finding, ToolStatus, format_bytes, path_size
+- `src/mac_care/config.py`: Config loader (TOML + defaults); per-category policy
 - `src/mac_care/git_safety.py`: git repo / worktree safety gate
-- `src/mac_care/scheduler.py`: launchd schedule install/uninstall
+- `src/mac_care/safety.py`: `is_protected()` — shared by scan.py and clean.py
+- `src/mac_care/ids.py`: stable finding ID (SHA-256 of category+path+risk+source)
+- `src/mac_care/summary.py`: ScanSummary — risk totals, top findings, tool warnings
+- `src/mac_care/review.py`: approve one `review` finding by stable ID
+- `src/mac_care/scheduler.py`: launchd plist install/uninstall with bootstrap activation
+- `src/mac_care/notification.py`: macOS notification via osascript
+- `src/mac_care/history.py`: report history index.html writer
+- `src/mac_care/privacy.py`: TCC database audit
+- `src/mac_care/uninstall.py`: app support file discovery and quarantine
+- `src/mac_care/compare.py`: diff two JSON reports
+- `src/mac_care/export.py`: Obsidian daily note export
 - `src/mac_care/tools/`: wrappers for external OSS utilities
   - `brew.py`: Homebrew cleanup findings
-  - `disk.py`: dua/dust disk tree integration
+  - `disk.py`: dua/du disk tree integration
   - `docker_check.py`: Docker disk usage findings
-  - `pearcleaner.py`: orphaned app support file findings
+  - `pearcleaner.py`: orphaned app support file findings (used by uninstall command)
 
 ## Open-Source Utility Strategy
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,22 @@ Tools like CleanMyMac are useful but cost money, run in the cloud, and make opaq
 - **Homebrew cache** — per-item reclaimable from `brew cleanup --dry-run`
 - **Docker** — reclaimable per category (images, volumes, containers, build cache)
 - **Orphaned app files** — via Pearcleaner, if installed
+- **iOS backups, Messages attachments, Time Machine snapshots** — surfaced as `review` findings
+- **Core dumps and crash logs** — per-item from `~/Library/Logs/DiagnosticReports`
+- **Broken symlinks** — detected across standard home library paths
+- **Login items** — lists persistent launch agents/daemons as `review` findings
+- **Stale runtime versions** — orphaned `pyenv`, `nvm`, `rbenv`, `sdkman`, `rustup` versions
+- **Orphaned dot directories** — inactive `~/.tool-version` directories not referenced by any project
+- **AI tool caches** — Copilot, Cursor, Windsurf, Continue, Ollama model caches
 - **Git safety gate** — any directory with a dirty or active repo is marked `protected` and never touched
-- **Developer tool health** — checks required tools, Homebrew PATH, Docker daemon
+- **Developer tool health** — checks required tools, SSH key encryption, redundant toolchains
 - **OSS recommendations** — lists missing optional tools with exact `brew install` commands
-- **Safe cleanup** — dry-run by default; `--execute` will quarantine (not `rm`) when implemented
+- **Safe cleanup** — dry-run by default; `--execute` quarantines (not `rm`) eligible findings
+- **App uninstall helper** — finds support files for a deleted app via Pearcleaner or native patterns
+- **Privacy audit** — reads macOS TCC database to list all permission grants
+- **Scheduled scans** — launchd-backed periodic scans with macOS notification on completion
+- **Report compare** — diff two JSON reports to surface new, resolved, and changed findings
+- **Obsidian export** — appends scan summary to your daily note (deduplication-safe)
 
 ---
 
@@ -51,9 +63,10 @@ Runs all scanners and writes a timestamped Markdown + JSON report to `~/.mac-car
 
 ```
 $ mac-care scan
-Scanned 42 findings, 8.3 GB observed.
-Markdown report: ~/.mac-care/reports/mac-care-2026-05-02T21-08-26.md
-JSON report:     ~/.mac-care/reports/mac-care-2026-05-02T21-08-26.json
+Scanned 42 findings, 8.3 GB observed (18 auto_safe / 21 review / 3 protected; 0 tool warnings).
+Markdown report: ~/.mac-care/reports/mac-care-2026-05-02-210826.md
+JSON report:     ~/.mac-care/reports/mac-care-2026-05-02-210826.json
+HTML report:     ~/.mac-care/reports/latest.html
 ```
 
 The report groups findings by risk level — `auto_safe`, `review`, `protected` — with size totals and per-item reasons.
@@ -107,6 +120,52 @@ mac-care review approve --report ~/.mac-care/reports/mac-care-2026-05-02-220005.
 mac-care review approve --report ~/.mac-care/reports/mac-care-2026-05-02-220005.json --finding-id abc123 --execute
 ```
 
+### `mac-care uninstall <AppName>`
+
+Finds the app bundle and all related support files. Dry-run by default; `--execute` quarantines them.
+
+```bash
+mac-care uninstall Zoom
+mac-care uninstall Zoom --execute
+```
+
+Uses Pearcleaner for deep discovery when installed; falls back to native `~/Library/` pattern matching.
+
+### `mac-care audit privacy`
+
+Reads the macOS TCC database and lists every permission grant grouped by service. Requires Full Disk Access.
+
+```bash
+mac-care audit privacy
+```
+
+### `mac-care schedule install`
+
+Installs a launchd plist that runs `mac-care scan --notify` on a configurable interval.
+
+```bash
+mac-care schedule install --interval 12   # every 12 hours
+mac-care schedule install --dry-run       # print plist without writing
+mac-care schedule uninstall
+```
+
+### `mac-care compare`
+
+Diffs two JSON reports and shows new, resolved, and changed findings.
+
+```bash
+mac-care compare old.json new.json
+mac-care compare old.json new.json --format json
+```
+
+### `mac-care export --format obsidian`
+
+Appends a scan summary block to today's Obsidian daily note. Skips silently if the same scan was already exported.
+
+```bash
+mac-care export --format obsidian --vault-path ~/Notes
+```
+
 ---
 
 ## Risk levels
@@ -152,11 +211,18 @@ Config file: `~/.config/mac-care/config.toml` — optional, defaults work out of
 reports_dir    = "~/.mac-care/reports"
 quarantine_dir = "~/.mac-care/quarantine"
 min_age_days   = 14
+retention_days = 30        # delete reports older than this
+retention_min_keep = 10    # always keep at least this many
 
 protected_paths = [
   "~/.ssh",
   "~/Projects/active-client",
 ]
+
+# additional_scan_paths = ["~/workspace"]  # scan extra workspace dirs
+
+# [policy.downloads]
+# min_age_days = 30   # per-category override
 ```
 
 Any path under `protected_paths` is never auto-cleaned. Paths containing active or dirty git repositories are also automatically protected at runtime — this is checked dynamically on every scan.
@@ -167,14 +233,26 @@ Any path under `protected_paths` is never auto-cleaned. Paths containing active 
 
 ```
 src/mac_care/
-  cli.py            Command routing
+  cli.py            Command routing (10 commands)
   scan.py           Orchestrates all scanners → list[Finding]
   doctor.py         Developer tool health checks + recommendations
   clean.py          Safe cleanup with git safety re-check
-  report.py         Markdown + JSON report writer
+  report.py         Markdown + JSON + HTML report writer; report rotation
   model.py          Finding, ToolStatus, format_bytes, path_size
   config.py         Config loader (TOML + defaults)
+  config.py         Per-category policy, retention, additional scan paths
   git_safety.py     find_git_repos, is_dirty, unsafe_repos
+  safety.py         is_protected() — shared by scan.py and clean.py
+  ids.py            Stable finding ID (SHA-256 of category+path+risk+source)
+  summary.py        ScanSummary — risk totals, top findings, tool warnings
+  review.py         approve_finding() by stable ID
+  scheduler.py      launchd plist install/uninstall
+  notification.py   macOS notification via osascript
+  history.py        Report history index.html writer
+  privacy.py        TCC database audit
+  uninstall.py      App support file discovery and quarantine
+  compare.py        Diff two JSON reports
+  export.py         Obsidian daily note export
   tools/
     brew.py         brew cleanup --dry-run integration
     disk.py         dua / du disk tree integration
@@ -200,12 +278,20 @@ Tests never touch the real filesystem and never call real external tools — all
 
 | Status | Feature |
 |---|---|
-| 🔜 | `mac-care schedule install/uninstall` — launchd plist for periodic automated scan |
-| 🔜 | `mac-care scan --stdout --format json` — pipe-friendly output |
-| 🔜 | `mac-care security` — KnockKnock (Objective-See) integration for login items, browser extensions |
-| ✅ | `mac-care clean --safe --execute` — move eligible files to quarantine dir instead of `rm` |
-| ✅ | Interactive review flow for `review`-class findings |
-| 🗓 | Report history and trending — compare consecutive scans |
+| ✅ | `mac-care scan` — full disk + developer + AI tool scan |
+| ✅ | `mac-care clean --safe --execute` — quarantine-based cleanup (never `rm`) |
+| ✅ | `mac-care review approve` — stable-ID approval for `review` findings |
+| ✅ | `mac-care schedule install/uninstall` — launchd periodic scan |
+| ✅ | `mac-care scan --stdout --format json/markdown` — pipe-friendly output |
+| ✅ | `mac-care uninstall <App>` — support file discovery and quarantine |
+| ✅ | `mac-care audit privacy` — TCC permission audit |
+| ✅ | `mac-care compare` — diff two JSON reports |
+| ✅ | `mac-care export --format obsidian` — daily note export |
+| ✅ | Report rotation — keep last N reports, configurable retention |
+| 🗓 | `mac-care security` — KnockKnock (Objective-See) integration for login items, browser extensions |
+| 🗓 | `mas` integration — Mac App Store update checks |
+| 🗓 | Xcode simulator cleanup — `xcrun simctl delete unavailable` |
+| 🗓 | Large file finder — top N files across home directory |
 
 See [`docs/technical-spec.md`](docs/technical-spec.md) for full feature status, known constraints, and decision log.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,13 +16,22 @@ This means:
 ```
 mac-care scan
      │
-     ├── _standard_paths()        → native findings (logs, caches, trash, tmp)
-     ├── _developer_paths()       → native findings (Xcode, Gradle)
-     ├── _downloads_review()      → native findings (old installers)
-     ├── _codex_workspace_review() → native + git_safety gate
-     ├── brew_cleanup_findings()  → calls brew cleanup --dry-run
-     ├── docker_findings()        → calls docker system df
-     └── pearcleaner_findings()   → calls pearcleaner list-orphaned
+     ├── _standard_paths()           → logs, caches, trash, tmp
+     ├── _developer_paths()          → Xcode, Gradle
+     ├── _downloads_review()         → old installers
+     ├── _workspace_review()         → workspace dirs + git_safety gate
+     ├── _ios_backups()              → ~/Library/Application Support/MobileSync
+     ├── _messages_attachments()     → ~/Library/Messages/Attachments
+     ├── _time_machine_snapshots()   → tmutil listlocalsnapshots
+     ├── _core_dumps_and_crash_logs() → ~/Library/Logs/DiagnosticReports
+     ├── _broken_symlinks()          → common ~/Library/ dirs
+     ├── _login_items()              → ~/Library/LaunchAgents/
+     ├── _stale_runtime_versions()   → pyenv/nvm/rbenv/sdkman/rustup
+     ├── _orphaned_dotdirs()         → inactive ~/.<tool> dirs
+     ├── _ai_tool_caches()           → Copilot/Cursor/Windsurf/Ollama
+     ├── brew_cleanup_findings()     → brew cleanup --dry-run
+     ├── docker_findings()           → docker system df
+     └── pearcleaner_findings()      → pearcleaner list-orphaned
               │
               ▼
         list[Finding]
@@ -30,7 +39,7 @@ mac-care scan
      ┌────────┴────────┐
      │                 │
  write_reports()    safe_clean()
- (Markdown+JSON)   (dry-run only, re-checks git_safety)
+ (MD+JSON+HTML)    (dry-run default, re-checks safety.is_protected)
 ```
 
 ---
@@ -80,17 +89,35 @@ unsafe_repos(root) -> list[Path]
 Loads `~/.config/mac-care/config.toml` with fallback to hardcoded defaults. Returns a frozen `Config` dataclass. The only file that reads from disk at import time (via `Config.load()`).
 
 ### `report.py`
-Writes Markdown + JSON reports to `config.reports_dir`. Reports are timestamped and never overwritten. The Markdown groups findings by risk level with size totals.
+Writes Markdown + JSON + HTML reports to `config.reports_dir`. Reports are timestamped and never overwritten. The Markdown groups findings by risk level with size totals. Also writes `latest.html` (static dashboard) and `index.html` (history index). After writing, calls `rotate_reports()` to enforce `retention_days` / `retention_min_keep`.
 
-JSON report findings include a stable `id` derived from category, path, risk, source, and reason. Review approval actions must reference this ID rather than accepting arbitrary paths from user input.
+JSON report findings include a stable `id` derived from category, path, risk, and source. `reason` and `size_bytes` are excluded from the hash so IDs remain stable across runs when subdirectory sizes change.
+
+### `ids.py`
+Computes stable finding IDs: `SHA-256(category + "\0" + path + "\0" + risk + "\0" + source)[:16]`.
+
+### `safety.py`
+Shared `is_protected(path, config) -> bool` used by both `scan.py` and `clean.py`. Checks `config.protected_paths` and `config.quarantine_dir` (quarantined files are never re-quarantined).
 
 ### `review.py`
 Loads a known JSON report and approves one `review` finding by stable ID. The first command path is dry-run; execution delegates to the quarantine move path in `clean.py`.
 
 **Rule:** `protected` findings are rejected, and arbitrary filesystem paths are never accepted from the review command.
 
-### `scheduler.py` *(planned)*
-Will write/remove a launchd plist at `~/Library/LaunchAgents/com.mac-care.periodic.plist` that runs `mac-care scan` on a configurable interval. Must support `--dry-run` to print the plist without writing it.
+### `scheduler.py`
+Writes/removes a launchd plist at `~/Library/LaunchAgents/com.mac-care.periodic.plist`. Activates via `launchctl bootstrap gui/<uid>` with `launchctl load` as fallback. Supports `--dry-run` to print the plist without writing.
+
+### `privacy.py`
+Reads the macOS TCC database at `~/Library/Application Support/com.apple.TCC/TCC.db`. `check_fda()` verifies Full Disk Access before any read. Handles both modern (`auth_value`) and legacy (`allowed`) schema columns. Mac absolute time offset: `978307200`.
+
+### `uninstall.py`
+`discover_support_files(app_path)` uses Pearcleaner (`list-orphaned --app`) when installed, falling back to native `~/Library/` pattern matching. `app_deletion_hint()` uses `os.access(path, W_OK)` to choose between a trash hint and a `sudo rm -rf` warning.
+
+### `compare.py`
+`compare_reports(path1, path2) -> CompareSummary` diffs findings by stable ID. Returns new, resolved, and changed (size/reason delta) finding lists. Renders as Markdown or JSON.
+
+### `export.py`
+`export_obsidian(reports_dir, vault_path)` reads the most recent JSON report, formats a frontmatter block, and appends it to today's daily note (`vault/YYYY-MM-DD.md`). Deduplicates by `generated_at` — safe to run multiple times.
 
 ---
 
@@ -205,7 +232,7 @@ These must hold at all times. Tests should catch regressions.
 
 1. `scan()` never modifies or deletes files.
 2. `safe_clean()` only acts on `risk == "auto_safe"` findings.
-3. Protected paths are checked in both `scan.py` (`_is_protected`) and `clean.py` (git safety re-check).
+3. Protected paths are checked via `safety.is_protected()` in both `scan.py` and `clean.py`; `clean.py` also re-checks the git safety gate before acting.
 4. Git safety gate returns `True` (unsafe) on any subprocess failure — never silently clears a repo.
 5. Every `tools/` wrapper returns `[]` on any error — never propagates exceptions to the caller.
 6. `dry_run=True` is the default for `safe_clean()`. Callers must explicitly pass `dry_run=False` to act.

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -36,46 +36,33 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 | Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
 | Quarantine cleanup execution | `mac-care clean --safe --execute` | Moves eligible `auto_safe` findings to quarantine with metadata; never `rm` |
 | Review approval flow | `mac-care review approve` | Approves one `review` finding by stable report finding ID; quarantine-only on execute |
-| Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/.mac-care/reports/` (configurable via `reports_dir`) |
+| Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/.mac-care/reports/` |
 | Report history index | `mac-care scan` | Writes read-only `index.html` listing previous JSON/Markdown/dashboard reports |
+| Report rotation | `mac-care scan` | Deletes old reports; configurable `retention_days` + `retention_min_keep` |
 | Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
-| GitHub Actions CI | `.github/workflows/test.yml` | `macos-latest`, Python 3.11, 73 tests |
+| Per-category policy | `config.toml` | `[policy.<category>]` overrides `min_age_days` per scan category |
+| Additional scan paths | `config.toml` | `additional_scan_paths` extends workspace scan beyond defaults |
+| Stable finding IDs | JSON reports | SHA-256 of `category+path+risk+source` — stable across runs |
+| iOS backups scan | `mac-care scan` | `~/Library/Application Support/MobileSync/Backup/` — `review` |
+| Messages attachments scan | `mac-care scan` | `~/Library/Messages/Attachments/` — `review` |
+| Time Machine snapshots scan | `mac-care scan` | `tmutil listlocalsnapshots /` — `review` |
+| Core dumps and crash logs | `mac-care scan` | `~/Library/Logs/DiagnosticReports/` — `review` |
+| Broken symlinks scan | `mac-care scan` | Common `~/Library/` dirs — `review` |
+| Login items scan | `mac-care scan` | `~/Library/LaunchAgents/` — lists persistent daemons as `review` |
+| Stale runtime versions | `mac-care scan` | pyenv, nvm, rbenv, sdkman, rustup orphaned versions — `review` |
+| Orphaned dot directories | `mac-care scan` | Inactive `~/.<tool>` dirs not referenced by any project — `review` |
+| AI tool caches | `mac-care scan` | Copilot, Cursor, Windsurf, Continue, Ollama model caches — `auto_safe` |
+| SSH key encryption check | `mac-care doctor` | Warns on unencrypted private keys in `~/.ssh/` |
+| Redundant toolchain check | `mac-care doctor` | Detects multiple Python/Node/Ruby/Go/Rust installations |
+| App uninstall helper | `mac-care uninstall <App>` | Support file discovery via Pearcleaner or native `~/Library/` patterns; `--execute` quarantines |
+| Privacy audit | `mac-care audit privacy` | Reads macOS TCC database; lists all permission grants by service |
+| Report compare | `mac-care compare` | Diffs two JSON reports; shows new, resolved, and changed findings |
+| Obsidian export | `mac-care export --format obsidian` | Appends scan summary to today's daily note; deduplication-safe |
+| GitHub Actions CI | `.github/workflows/test.yml` | `macos-latest`, Python 3.11, 163 tests |
 | Branch protection | GitHub | Requires CI to pass before merge to main |
 | Issue/PR templates | `.github/` | epic / story / enabler / bug + PR template |
 
 ---
-
-### 🔜 In progress (GitHub issues open, Codex active)
-
-#### Epic: Quarantine-based cleanup ([#4](https://github.com/djspiceroute/mac-care/issues/4))
-
-| Feature | Issue | Notes |
-|---|---|---|
-| Move `auto_safe` findings to quarantine | [#12](https://github.com/djspiceroute/mac-care/issues/12) | Implemented for eligible item-level/rebuildable findings; broad containers remain skipped |
-| Review approval flow | [#13](https://github.com/djspiceroute/mac-care/issues/13) | Implemented as stable-ID approval from JSON reports; dashboard wiring remains future work |
-| Dashboard action safety model | [#14](https://github.com/djspiceroute/mac-care/issues/14) | Documented in `docs/dashboard-action-safety.md`; implementation remains future work |
-
-#### Epic: Unified local report viewer ([#2](https://github.com/djspiceroute/mac-care/issues/2))
-
-| Feature | Issue | Notes |
-|---|---|---|
-| Compact scan summary model | [#8](https://github.com/djspiceroute/mac-care/issues/8) | Lightweight summary struct for dashboard and notifications |
-| HTML dashboard from scan results | [#9](https://github.com/djspiceroute/mac-care/issues/9) | Static HTML report generated alongside Markdown + JSON |
-| Report history index | [#10](https://github.com/djspiceroute/mac-care/issues/10) | Implemented as read-only `index.html`; trend deltas remain future work |
-| Stdout and format flags | [#6](https://github.com/djspiceroute/mac-care/issues/6) | `mac-care scan --stdout --format json/markdown` for piping |
-
-#### Epic: Periodic local scan workflow ([#3](https://github.com/djspiceroute/mac-care/issues/3))
-
-| Feature | Issue | Notes |
-|---|---|---|
-| launchd schedule install/uninstall | [#5](https://github.com/djspiceroute/mac-care/issues/5) | Writes plist to `~/Library/LaunchAgents/`; `--dry-run` prints plist |
-| macOS notification after scheduled scan | [#11](https://github.com/djspiceroute/mac-care/issues/11) | Post summary notification on scan completion |
-
-#### Enablers
-
-| Feature | Issue | Notes |
-|---|---|---|
-| Pearcleaner live test | [#7](https://github.com/djspiceroute/mac-care/issues/7) | Installed cask and verified CLI; `list-orphaned` timed out live |
 
 ---
 
@@ -134,21 +121,25 @@ Key categories protected by default:
 
 ## Test Coverage
 
-107 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
+163 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
 
 | Test file | Coverage |
 |---|---|
 | `tests/test_clean.py` | Dry-run default, quarantine moves, metadata, protected-path re-check, non-itemized skip |
 | `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
+| `tests/test_compare.py` | New/resolved/changed finding diff, zero-size reason diff, JSON/Markdown render |
+| `tests/test_export.py` | Obsidian daily note creation, deduplication, missing reports error |
 | `tests/test_history.py` | Report history loading, malformed report skipping, index rendering/writing |
-| `tests/test_ids.py` | Stable finding ID behavior |
+| `tests/test_ids.py` | Stable finding ID behavior; reason/size exclusion; risk-change stability |
 | `tests/test_notification.py` | Notification text and graceful `osascript` delivery behavior |
-| `tests/test_scheduler.py` | launchd plist rendering, dry-run install/uninstall, plist write/remove using temp paths |
-| `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard |
+| `tests/test_safety.py` | `is_protected()` — protected paths, quarantine dir, non-protected paths |
+| `tests/test_scan.py` | All new scan functions: iOS backups, Messages, Time Machine, crash logs, broken symlinks, login items, stale runtimes, orphaned dotdirs, AI tool caches |
+| `tests/test_scheduler.py` | launchd plist rendering, bootstrap activation, dry-run install/uninstall, plist write/remove |
+| `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard, rotation |
 | `tests/test_review.py` | Review approval dry-run, quarantine execution, protected/unknown finding rejection |
 | `tests/test_summary.py` | Risk totals, top findings, tool warning count |
 | `tests/test_git_safety.py` | `find_git_repos`, `is_dirty`, `has_active_worktrees`, `unsafe_repos` — all degradation paths |
-| `tests/test_doctor.py` | `recommend_tools` — missing/installed/empty/key/brew-prefix |
+| `tests/test_doctor.py` | `recommend_tools`, SSH key encryption check, redundant toolchain detection |
 | `tests/tools/test_brew.py` | `_parse_size`, full parse, sizes, risk/source tagging, all degradation |
 | `tests/tools/test_disk.py` | dua path, du fallback, `size_of`, nonexistent, summary format |
 | `tests/tools/test_docker.py` | `_parse_docker_size`, 4-category parse, reclaimable sizes, hints, degradation |
@@ -180,7 +171,7 @@ Reports include a reusable compact summary used by CLI output and intended for f
 }
 ```
 
-JSON report findings also include stable IDs used for review approval:
+JSON report findings also include stable IDs used for review approval. The ID is a 16-character hex prefix of `SHA-256(category + "\0" + path + "\0" + risk + "\0" + source)`. `reason` and `size_bytes` are intentionally excluded so IDs remain stable across scans even when subdirectory sizes change:
 
 ```json
 {
@@ -188,7 +179,9 @@ JSON report findings also include stable IDs used for review approval:
     {
       "id": "3b6d0f0d9a8c1e2f",
       "category": "orphaned_app_files",
-      "risk": "review"
+      "path": "/Users/you/Library/Application Support/Zoom",
+      "risk": "review",
+      "source": "pearcleaner"
     }
   ]
 }
@@ -223,8 +216,13 @@ Each default scan also updates `index.html` in the reports directory. The index 
 | Disk | Xcode DerivedData, Gradle cache, user caches | `auto_safe` / `review` |
 | Disk (enriched) | Top subdirs listed in reason for dirs >500 MB | — |
 | Downloads | Old .dmg / .pkg / .zip past `min_age_days` | `review` |
-| Pearcleaner | Orphaned app support paths | `review` |
+| Pearcleaner | Orphaned app support paths (uninstall command) | `review` |
 | Git workspaces | Any workspace with active/dirty repos | `protected` |
+| Native (scan.py) | iOS backups, Messages attachments, Time Machine snapshots | `review` |
+| Native (scan.py) | Core dumps, crash logs, broken symlinks, login items | `review` |
+| Native (scan.py) | Stale runtime versions (pyenv/nvm/rbenv/sdkman/rustup) | `review` |
+| Native (scan.py) | Orphaned dot directories | `review` |
+| Native (scan.py) | AI tool caches (Copilot, Cursor, Ollama, etc.) | `auto_safe` |
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates README with full feature list, all 10 commands, corrected project layout, accurate roadmap, and `~/.mac-care` paths throughout
- Updates `docs/technical-spec.md` with 20 new shipped features, test count 107 → 163, correct `finding_id` hash spec (reason/size excluded), expanded scan category table, and removes stale "In Progress" section
- Updates `docs/architecture.md` with full 13-function Data Flow diagram, new module docs for `safety.py`, `ids.py`, `privacy.py`, `uninstall.py`, `compare.py`, `export.py`, `scheduler.py` (removes "planned" label), and corrected Safety Invariant #3 (`safety.is_protected()`)
- Updates `AGENTS.md` Architecture section with all 20 modules and correct quarantine path

## Closes

Closes #42

## Test plan

- [x] 163 tests passing (`python -m pytest tests/ -q`)
- [x] Docs-only change — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)