### PR TITLE
docs: update vision and roadmap for phase 2 developer health console

### DIFF
--- a/.gemini.md
+++ b/.gemini.md
@@ -1,0 +1,30 @@
+# mac-care Gemini Agent Instructions
+
+This file provides project-specific guidance for the Gemini agent. It inherits principles from `AGENTS.md`.
+
+## Source of Truth
+1. Direct user instruction
+2. `.gemini.md` (this file)
+3. `AGENTS.md`
+4. GitHub Issues
+
+## Key Mandates
+- **Report-First**: Prefer showing findings before deletion.
+- **Dry-Run by Default**: Destructive actions must require explicit flags (`--execute`, `--purge`).
+- **Safety Gates**: Always run `git_safety.py` and check `is_protected()` before modifying files.
+- **OSS Integration**: Use `dua`, `brew`, `docker`, and `pearcleaner` instead of rebuilding scanners.
+- **Branch Strategy**: Use `gemini/` prefix for branches (e.g., `gemini/quarantine-cmd`).
+- **Conventional Commits**: Use `feat:`, `fix:`, `test:`, `docs:`, `chore:`, `refactor:`.
+
+## Architecture Reference
+- `cli.py`: Command routing.
+- `scan.py`: Finding discovery.
+- `clean.py`: Deletion/quarantine orchestration.
+- `safety.py`: Shared protection checks.
+- `ids.py`: Stable finding IDs.
+- `tools/`: Wrapper modules for external binaries.
+
+## Testing Guidelines
+- **No Side Effects**: Tests must not touch the real filesystem (use `tmp_path`).
+- **No Real Tools**: Mock all `subprocess` calls.
+- **Independent**: Modules must be testable in isolation.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 AGENTS.local.md
 CLAUDE.md
 .claude/
+.gemini.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,3 +197,46 @@ After completing any item, include:
 4. Limitations / risks
 5. Recommended next steps
 
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **mac-care** (1138 symbols, 1864 relationships, 75 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/mac-care/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/mac-care/clusters` | All functional areas |
+| `gitnexus://repo/mac-care/processes` | All execution flows |
+| `gitnexus://repo/mac-care/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/README.md
+++ b/README.md
@@ -1,43 +1,52 @@
 # mac-care
 
-> A free, local macOS maintenance CLI for developer machines — report-first, no surprise deletions.
+> A free, local **Developer Health Console** for macOS — not just a cleaner, but a visibility layer for your machine.
 
 [![Tests](https://github.com/djspiceroute/mac-care/actions/workflows/test.yml/badge.svg)](https://github.com/djspiceroute/mac-care/actions/workflows/test.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-mac-care is a **coordinator, not a scanner**. It calls trusted OSS tools — Homebrew, Docker, `dua`, Pearcleaner — collects their output into a unified model, and produces Markdown + JSON reports you can act on. Nothing is deleted without your explicit intent.
+mac-care is a **coordinator, not a scanner**. It integrates trusted OSS tools — Homebrew, Docker, `dua`, Pearcleaner — to give you a unified view of your system's storage, security, and tool health. 
+
+Everything is **local-only, transparent, and reversible**.
 
 ---
 
 ## Why
 
-Tools like CleanMyMac are useful but cost money, run in the cloud, and make opaque decisions. mac-care is the opposite: free, fully local, transparent about what it found and why, and designed to be safe enough to run on a machine with active work.
+Developer machines are complex. Tools like CleanMyMac are useful but opaque and expensive. mac-care is designed for engineers who want:
+- **Visibility**: See exactly where space went and why.
+- **Safety**: Never delete active work (built-in git safety gate).
+- **Reversibility**: Files are moved to quarantine, never instantly purged.
+- **Local Control**: No cloud uploads, no "AI" magic, just grep-able reports and local logs.
 
 ---
 
 ## Features
 
-- **Disk scan** — logs, caches, trash, tmp, Xcode DerivedData, Gradle cache, old installers
-- **Homebrew cache** — per-item reclaimable from `brew cleanup --dry-run`
-- **Docker** — reclaimable per category (images, volumes, containers, build cache)
-- **Orphaned app files** — via Pearcleaner, if installed
-- **iOS backups, Messages attachments, Time Machine snapshots** — surfaced as `review` findings
-- **Core dumps and crash logs** — per-item from `~/Library/Logs/DiagnosticReports`
-- **Broken symlinks** — detected across standard home library paths
-- **Login items** — lists persistent launch agents/daemons as `review` findings
-- **Stale runtime versions** — orphaned `pyenv`, `nvm`, `rbenv`, `sdkman`, `rustup` versions
-- **Orphaned dot directories** — inactive `~/.tool-version` directories not referenced by any project
-- **AI tool caches** — Copilot, Cursor, Windsurf, Continue, Ollama model caches
-- **Git safety gate** — any directory with a dirty or active repo is marked `protected` and never touched
-- **Developer tool health** — checks required tools, SSH key encryption, redundant toolchains
-- **OSS recommendations** — lists missing optional tools with exact `brew install` commands
-- **Safe cleanup** — dry-run by default; `--execute` quarantines (not `rm`) eligible findings
-- **App uninstall helper** — finds support files for a deleted app via Pearcleaner or native patterns
-- **Privacy audit** — reads macOS TCC database to list all permission grants
-- **Scheduled scans** — launchd-backed periodic scans with macOS notification on completion
-- **Report compare** — diff two JSON reports to surface new, resolved, and changed findings
-- **Obsidian export** — appends scan summary to your daily note (deduplication-safe)
+- **Disk scan** — logs, caches, trash, tmp, Xcode DerivedData, Gradle cache, old installers.
+- **Homebrew cache** — per-item reclaimable from `brew cleanup --dry-run`.
+- **Docker** — reclaimable per category (images, volumes, containers, build cache).
+- **Orphaned app files** — discovery via Pearcleaner integration.
+- **Persistence Visibility** — list login items, launch agents, and launch daemons.
+- **Dev Tool Health** — check required tools, SSH key encryption, and redundant toolchains.
+- **Privacy Audit** — audit macOS TCC permissions (Full Disk Access required).
+- **Git Safety Gate** — any directory with a dirty or active repo is automatically protected.
+- **Safe Cleanup** — dry-run by default; `--execute` quarantines (not `rm`) findings.
+- **Report History** — timestamped Markdown + JSON reports with historical rotation.
+
+---
+
+## Security & Privacy Boundaries
+
+mac-care is built for security-conscious users who are proficient with the terminal.
+
+1. **Local-Only**: All scanning and reporting happens on your machine. No data is ever uploaded.
+2. **Read-Only Scans**: The `scan` command never modifies your files. It only observes.
+3. **Quarantine Model**: Destructive actions move files to `~/.mac-care/quarantine/`. They are not deleted from disk until you explicitly purge them.
+4. **Guided Sudo**: mac-care never runs `sudo` automatically. For actions requiring elevated permissions (like deleting system-protected apps), it provides the exact command for you to review and run manually.
+5. **Full Disk Access**: Required for deep audits (like TCC or Messages attachments). mac-care explains why FDA is needed and how to grant/revoke it.
+6. **Tool Transparency**: Reports record the absolute paths of external binaries used, ensuring you know exactly what was executed.
 
 ---
 
@@ -58,242 +67,60 @@ No external dependencies required. Optional OSS tools (listed below) extend what
 ## Commands
 
 ### `mac-care scan`
-
-Runs all scanners and writes a timestamped Markdown + JSON report to `~/.mac-care/reports/`.
-
-```
-$ mac-care scan
-Scanned 42 findings, 8.3 GB observed (18 auto_safe / 21 review / 3 protected; 0 tool warnings).
-Markdown report: ~/.mac-care/reports/mac-care-2026-05-02-210826.md
-JSON report:     ~/.mac-care/reports/mac-care-2026-05-02-210826.json
-HTML report:     ~/.mac-care/reports/latest.html
-```
-
-The report groups findings by risk level — `auto_safe`, `review`, `protected` — with size totals and per-item reasons.
+Runs all scanners and writes reports to `~/.mac-care/reports/`.
+- Use `--stdout` for pipe-friendly output.
+- Use `--notify` to get a macOS notification on completion.
 
 ### `mac-care doctor`
-
-Checks developer tool health: required tools, Homebrew PATH, Docker daemon reachability.
-
-```
-$ mac-care doctor
-brew:           ok
-git:            ok
-docker_daemon:  ok - daemon is reachable
-homebrew_path:  ok
-pnpm:           missing - not on PATH
-```
-
-### `mac-care tools status`
-
-Shows all required and optional tools with installed/missing status.
-
-### `mac-care tools recommend`
-
-Lists missing optional OSS tools grouped by function, with install commands.
-
-```
-$ mac-care tools recommend
-
-Disk analysis:
-  dua     Fast parallel disk usage tree   →  brew install dua-cli
-  dust    Rust-based directory size tree  →  brew install dust
-
-App cleanup:
-  pearcleaner  Orphaned app support files  →  brew install --cask pearcleaner
-```
-
-### `mac-care clean --safe --dry-run`
-
-Prints what would be cleaned from `auto_safe` findings. Does not delete anything.
+Checks developer tool health: required tools, PATH resolution, Docker daemon, SSH key encryption.
 
 ### `mac-care clean --safe --execute`
-
-Moves eligible `auto_safe` findings to the configured quarantine directory. This is intentionally narrower than scan output: broad containers such as `~/Library/Caches` and `/tmp` are skipped until scan itemizes their contents.
+Moves eligible `auto_safe` findings to quarantine.
+- Use `--purge` to permanently delete `auto_safe` findings (requires confirmation).
 
 ### `mac-care review approve`
-
-Approves one `review` finding from a JSON report by stable finding ID. Dry-run is the default.
-
-```bash
-mac-care review approve --report ~/.mac-care/reports/mac-care-2026-05-02-220005.json --finding-id abc123
-mac-care review approve --report ~/.mac-care/reports/mac-care-2026-05-02-220005.json --finding-id abc123 --execute
-```
+Approves one `review` finding from a JSON report by its stable ID.
 
 ### `mac-care uninstall <AppName>`
-
-Finds the app bundle and all related support files. Dry-run by default; `--execute` quarantines them.
-
-```bash
-mac-care uninstall Zoom
-mac-care uninstall Zoom --execute
-```
-
-Uses Pearcleaner for deep discovery when installed; falls back to native `~/Library/` pattern matching.
+Finds an app bundle and its support files. Provides guidance for removal or automates quarantine.
 
 ### `mac-care audit privacy`
-
-Reads the macOS TCC database and lists every permission grant grouped by service. Requires Full Disk Access.
-
-```bash
-mac-care audit privacy
-```
+Lists all macOS TCC permissions granted to apps. (Requires Full Disk Access).
 
 ### `mac-care schedule install`
-
-Installs a launchd plist that runs `mac-care scan --notify` on a configurable interval.
-
-```bash
-mac-care schedule install --interval 12   # every 12 hours
-mac-care schedule install --dry-run       # print plist without writing
-mac-care schedule uninstall
-```
+Installs a `launchd` plist for periodic automated scans.
 
 ### `mac-care compare`
-
-Diffs two JSON reports and shows new, resolved, and changed findings.
-
-```bash
-mac-care compare old.json new.json
-mac-care compare old.json new.json --format json
-```
-
-### `mac-care export --format obsidian`
-
-Appends a scan summary block to today's Obsidian daily note. Skips silently if the same scan was already exported.
-
-```bash
-mac-care export --format obsidian --vault-path ~/Notes
-```
+Diffs two JSON reports to show new, resolved, or changed findings.
 
 ---
 
-## Risk levels
+## Roadmap: Phase 2
 
-Every finding has a risk level that controls what mac-care will and won't do automatically.
-
-| Level | Meaning | Example |
-|---|---|---|
-| `auto_safe` | Rebuildable or declared safe by the source tool | Homebrew cache, Xcode DerivedData |
-| `review` | Needs human confirmation before deletion | Docker volumes, old installers, orphaned app files |
-| `protected` | Never touched — ever | Dirty/active git repos, paths listed in config |
-
-Only `auto_safe` findings are eligible for `mac-care clean`. `review` and `protected` findings only appear in reports.
+| Status | Feature |
+|---|---|
+| ✅ | **App Uninstall** — Pearcleaner-first support file discovery |
+| ✅ | **Privacy Audit** — TCC database permission viewer |
+| ✅ | **Report Compare** — Diffing two scan results |
+| ✅ | **Report Rotation** — Automated cleanup of old reports |
+| 🗓 | **Quarantine Management** — status, purge, and auto-rotation (#44, #45) |
+| 🗓 | **Security Audit** — Persistence visibility for LaunchAgents/Daemons (#54) |
+| 🗓 | **Xcode Dev Cleanup** — Simulator and device support cleanup (#53) |
+| 🗓 | **Large File Finder** — Global scanner with protected-path exclusions (#51) |
+| 🗓 | **Interactive Dashboard** — Terminal-based (TUI) management console (#64) |
+| 🗓 | **Action Service Layer** — Reusable engine for CLI and Dashboard (#61) |
+| 🗓 | **Quarantine Restore** — Boringly reversible "Undo" for cleanup (#62) |
 
 ---
 
 ## OSS integrations
 
-Each integration lives in `src/mac_care/tools/` and degrades gracefully — if the tool is not installed, it returns an empty finding list and the scan continues uninterrupted.
-
 | Module | Backed by | What it surfaces |
 |---|---|---|
-| `tools/brew.py` | `brew cleanup --dry-run` | Per-item Homebrew cache reclaimable |
-| `tools/disk.py` | `dua` (primary) / `du` (fallback) | Directory sizes; top-subdir breakdown for dirs >500 MB |
-| `tools/docker_check.py` | `docker system df` | Reclaimable per category |
-| `tools/pearcleaner.py` | `pearcleaner list-orphaned` | App support files orphaned after app deletion |
-
-Install the recommended backends for the best results:
-
-```bash
-brew install dua-cli              # fast parallel disk analysis
-brew install --cask pearcleaner   # orphaned app file scanner
-```
-
----
-
-## Configuration
-
-Config file: `~/.config/mac-care/config.toml` — optional, defaults work out of the box.
-
-```toml
-[policy]
-reports_dir    = "~/.mac-care/reports"
-quarantine_dir = "~/.mac-care/quarantine"
-min_age_days   = 14
-retention_days = 30        # delete reports older than this
-retention_min_keep = 10    # always keep at least this many
-
-protected_paths = [
-  "~/.ssh",
-  "~/Projects/active-client",
-]
-
-# additional_scan_paths = ["~/workspace"]  # scan extra workspace dirs
-
-# [policy.downloads]
-# min_age_days = 30   # per-category override
-```
-
-Any path under `protected_paths` is never auto-cleaned. Paths containing active or dirty git repositories are also automatically protected at runtime — this is checked dynamically on every scan.
-
----
-
-## Project layout
-
-```
-src/mac_care/
-  cli.py            Command routing (10 commands)
-  scan.py           Orchestrates all scanners → list[Finding]
-  doctor.py         Developer tool health checks + recommendations
-  clean.py          Safe cleanup with git safety re-check
-  report.py         Markdown + JSON + HTML report writer; report rotation
-  model.py          Finding, ToolStatus, format_bytes, path_size
-  config.py         Config loader (TOML + defaults)
-  config.py         Per-category policy, retention, additional scan paths
-  git_safety.py     find_git_repos, is_dirty, unsafe_repos
-  safety.py         is_protected() — shared by scan.py and clean.py
-  ids.py            Stable finding ID (SHA-256 of category+path+risk+source)
-  summary.py        ScanSummary — risk totals, top findings, tool warnings
-  review.py         approve_finding() by stable ID
-  scheduler.py      launchd plist install/uninstall
-  notification.py   macOS notification via osascript
-  history.py        Report history index.html writer
-  privacy.py        TCC database audit
-  uninstall.py      App support file discovery and quarantine
-  compare.py        Diff two JSON reports
-  export.py         Obsidian daily note export
-  tools/
-    brew.py         brew cleanup --dry-run integration
-    disk.py         dua / du disk tree integration
-    docker_check.py docker system df integration
-    pearcleaner.py  pearcleaner list-orphaned integration
-```
-
----
-
-## Development
-
-```bash
-pip install -e ".[dev]"       # install with dev dependencies
-python -m pytest tests/ -v    # run all tests (~0.3s)
-mac-care scan                  # live scan
-```
-
-Tests never touch the real filesystem and never call real external tools — all subprocess calls are mocked. See `AGENTS.md` for contribution rules and branch conventions.
-
----
-
-## Roadmap
-
-| Status | Feature |
-|---|---|
-| ✅ | `mac-care scan` — full disk + developer + AI tool scan |
-| ✅ | `mac-care clean --safe --execute` — quarantine-based cleanup (never `rm`) |
-| ✅ | `mac-care review approve` — stable-ID approval for `review` findings |
-| ✅ | `mac-care schedule install/uninstall` — launchd periodic scan |
-| ✅ | `mac-care scan --stdout --format json/markdown` — pipe-friendly output |
-| ✅ | `mac-care uninstall <App>` — support file discovery and quarantine |
-| ✅ | `mac-care audit privacy` — TCC permission audit |
-| ✅ | `mac-care compare` — diff two JSON reports |
-| ✅ | `mac-care export --format obsidian` — daily note export |
-| ✅ | Report rotation — keep last N reports, configurable retention |
-| 🗓 | `mac-care security` — KnockKnock (Objective-See) integration for login items, browser extensions |
-| 🗓 | `mas` integration — Mac App Store update checks |
-| 🗓 | Xcode simulator cleanup — `xcrun simctl delete unavailable` |
-| 🗓 | Large file finder — top N files across home directory |
-
-See [`docs/technical-spec.md`](docs/technical-spec.md) for full feature status, known constraints, and decision log.
+| `tools/brew.py` | `brew cleanup` | Homebrew cache reclaimable |
+| `tools/disk.py` | `dua` / `du` | Large directory trees |
+| `tools/docker_check.py` | `docker system df` | Container and volume waste |
+| `tools/pearcleaner.py` | `pearcleaner` | Orphaned app support files |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,239 +2,113 @@
 
 ## Design Philosophy
 
-mac-care is an **orchestrator, not a scanner**. It calls trusted OSS tools, parses their output into a unified data model, and applies a policy layer on top. The custom code handles: policy, scheduling, protected paths, review gates, report formatting, and developer tool health. The OSS tools handle: actual disk analysis, package cache detection, container waste detection, and app leftover scanning.
+mac-care is an **orchestrator and health console**, not just a cleaner. It calls trusted OSS tools, parses their output into a unified data model, and applies a developer-centric policy layer.
 
-This means:
-- When the report says "brew can reclaim 109 MB", that's because `brew cleanup --dry-run` said so — not because we reimplemented brew's logic.
-- When a Docker finding appears, `docker system df` is the source of truth.
-- Our code stays small and focused on coordination.
+The architecture is designed around **Transparency, Reversibility, and Visibility**.
 
 ---
 
-## Data Flow
+## Data & Action Flow (Phase 2)
 
 ```
-mac-care scan
+User / Scheduler
      │
-     ├── _standard_paths()           → logs, caches, trash, tmp
-     ├── _developer_paths()          → Xcode, Gradle
-     ├── _downloads_review()         → old installers
-     ├── _workspace_review()         → workspace dirs + git_safety gate
-     ├── _ios_backups()              → ~/Library/Application Support/MobileSync
-     ├── _messages_attachments()     → ~/Library/Messages/Attachments
-     ├── _time_machine_snapshots()   → tmutil listlocalsnapshots
-     ├── _core_dumps_and_crash_logs() → ~/Library/Logs/DiagnosticReports
-     ├── _broken_symlinks()          → common ~/Library/ dirs
-     ├── _login_items()              → ~/Library/LaunchAgents/
-     ├── _stale_runtime_versions()   → pyenv/nvm/rbenv/sdkman/rustup
-     ├── _orphaned_dotdirs()         → inactive ~/.<tool> dirs
-     ├── _ai_tool_caches()           → Copilot/Cursor/Windsurf/Ollama
-     ├── brew_cleanup_findings()     → brew cleanup --dry-run
-     ├── docker_findings()           → docker system df
-     └── pearcleaner_findings()      → pearcleaner list-orphaned
+     ▼
+[ Interactive UI / CLI / Watcher ]
+     │
+     ├── mac_care.scan.scan()         → Discovery (list[Finding])
+     │                                  │
+     ▼                                  ▼
+[ Action Service Layer ] ◀─────── [ State Store ] (~/.mac-care/state.json)
+     │                                  │
+     ├── quarantine_finding()           │
+     ├── purge_finding()                │
+     └── restore_finding()        ◀─────┘ (via ~/.mac-care/receipts/)
               │
               ▼
-        list[Finding]
-              │
-     ┌────────┴────────┐
-     │                 │
- write_reports()    safe_clean()
- (MD+JSON+HTML)    (dry-run default, re-checks safety.is_protected)
+    [ File System Action ]
 ```
+
+---
+
+## Service Layer & State Management
+
+### `ActionService` (Proposed)
+Phase 2 extracts action logic (quarantine, purge, restore) from `cli.py` into a reusable service. This allows the CLI, a TUI (Terminal UI), and background tasks to share the same safety gates and logic.
+
+### State Store (`state.json`)
+Instead of relying solely on timestamped reports, `mac-care` maintains a "current state" cache. This store tracks:
+- Last scan results.
+- Pending review approvals.
+- Active quarantine runs.
+- Tool health status.
+
+### Action Receipts & Restore
+Every destructive action (even to quarantine) generates an **Action Receipt**.
+- **Location**: `~/.mac-care/receipts/<run_id>/<finding_id>.json`
+- **Content**: Original path, destination path, size, hash, and timestamp.
+- **Restore**: The `restore` command uses these receipts to move files back to their original location, handling path conflicts safely.
 
 ---
 
 ## Module Boundaries
 
 ### `model.py`
-Pure data types. No I/O, no subprocess calls. Importing this never has side effects.
-
-```python
-Finding(category, path, size_bytes, risk, reason, source)
-ToolStatus(name, status, detail)
-format_bytes(size) -> str
-path_size(path) -> int   # slow Python fallback — prefer tools/disk.py
-```
-
-`source` field values: `"native"` | `"brew"` | `"dua"` | `"docker"` | `"pearcleaner"`
-
-`risk` field values: `"auto_safe"` | `"review"` | `"protected"`
+Pure data types (Finding, ToolStatus, ScanSummary). No I/O. Importing this never has side effects.
 
 ### `scan.py`
-The main orchestrator. Calls all scanner functions and returns `list[Finding]`. No deletion logic here. Applies the git safety gate to workspace paths. Uses `size_of()` from `tools/disk.py` instead of the slow Python rglob for directory sizing.
+The read-only orchestrator. Calls all scanner functions and returns `list[Finding]`. Applies the git safety gate to workspace paths.
+**Invariant:** Never modifies the filesystem.
 
-**Rule:** `scan.py` must never delete or modify files. It is read-only.
-
-### `clean.py`
-Acts on `auto_safe` findings only. Re-checks the git safety gate before touching workspace-adjacent categories (belt-and-suspenders). Deletion is not implemented yet — `--dry-run` is the only operative mode. When deletion is added, it must move files to `config.quarantine_dir`, never `rm`.
-
-**Rule:** Only `auto_safe` risk findings are eligible. `review` and `protected` are never touched.
-
-`--execute` moves eligible item-level/rebuildable findings to quarantine. Broad container findings such as `user_caches`, `user_logs`, `trash`, and `tmp` remain skipped until scan itemizes their contents. Every move writes metadata with the original path, quarantine path, risk, source, reason, and timestamp.
+### `clean.py` (Evolving to Action Service)
+Orchestrates the transition from finding to quarantine or purge. 
+- Re-checks `is_protected` and `git_safety` immediately before execution.
+- **New for Phase 2:** Path-drift detection. If a file has changed size or type since the scan, the action is aborted.
 
 ### `doctor.py`
-Checks required developer tools (`REQUIRED_TOOLS`), optional OSS integrations (`OSS_OPTIONAL_TOOLS`), Homebrew PATH, and Docker daemon reachability. `recommend_tools()` returns missing optional tools with install hints from `TOOL_RECOMMENDATIONS`.
+Checks required developer tools, optional OSS integrations, Homebrew PATH, and Docker daemon reachability.
 
 ### `git_safety.py`
-Detects dirty or active git repos under a path. Used by `scan.py` (to mark Codex workspaces as `protected`) and `clean.py` (to re-check before acting). All subprocess calls fail-safe — timeouts and missing `git` binary both return `True` (treat as dirty/active).
-
-```python
-find_git_repos(root, max_depth=4) -> list[Path]
-is_dirty(repo_path) -> bool
-has_active_worktrees(repo_path) -> bool
-unsafe_repos(root) -> list[Path]
-```
-
-### `config.py`
-Loads `~/.config/mac-care/config.toml` with fallback to hardcoded defaults. Returns a frozen `Config` dataclass. The only file that reads from disk at import time (via `Config.load()`).
-
-### `report.py`
-Writes Markdown + JSON + HTML reports to `config.reports_dir`. Reports are timestamped and never overwritten. The Markdown groups findings by risk level with size totals. Also writes `latest.html` (static dashboard) and `index.html` (history index). After writing, calls `rotate_reports()` to enforce `retention_days` / `retention_min_keep`.
-
-JSON report findings include a stable `id` derived from category, path, risk, and source. `reason` and `size_bytes` are excluded from the hash so IDs remain stable across runs when subdirectory sizes change.
-
-### `ids.py`
-Computes stable finding IDs: `SHA-256(category + "\0" + path + "\0" + risk + "\0" + source)[:16]`.
+Detects dirty or active git repos under a path. Used as a safety gate to protect active work.
 
 ### `safety.py`
-Shared `is_protected(path, config) -> bool` used by both `scan.py` and `clean.py`. Checks `config.protected_paths` and `config.quarantine_dir` (quarantined files are never re-quarantined).
+Centralized protection logic. Checks `config.protected_paths`, git state, and system-protected locations.
 
-### `review.py`
-Loads a known JSON report and approves one `review` finding by stable ID. The first command path is dry-run; execution delegates to the quarantine move path in `clean.py`.
+### `ids.py`
+Computes stable finding IDs derived from the finding's **structural identity** (category + path + risk + source).
 
-**Rule:** `protected` findings are rejected, and arbitrary filesystem paths are never accepted from the review command.
+### `report.py`
+Generates human-readable (MD, HTML) and machine-readable (JSON) artifacts. Manages report rotation.
 
-### `scheduler.py`
-Writes/removes a launchd plist at `~/Library/LaunchAgents/com.mac-care.periodic.plist`. Activates via `launchctl bootstrap gui/<uid>` with `launchctl load` as fallback. Supports `--dry-run` to print the plist without writing.
-
-### `privacy.py`
-Reads the macOS TCC database at `~/Library/Application Support/com.apple.TCC/TCC.db`. `check_fda()` verifies Full Disk Access before any read. Handles both modern (`auth_value`) and legacy (`allowed`) schema columns. Mac absolute time offset: `978307200`.
+### `privacy.py` & `security.py`
+Specialized audit modules. `privacy.py` handles TCC database reads (requires FDA); `security.py` (Phase 2) handles persistence auditing (LaunchAgents/Daemons).
 
 ### `uninstall.py`
-`discover_support_files(app_path)` uses Pearcleaner (`list-orphaned --app`) when installed, falling back to native `~/Library/` pattern matching. `app_deletion_hint()` uses `os.access(path, W_OK)` to choose between a trash hint and a `sudo rm -rf` warning.
+App-specific discovery. Pairs bundle identification with support-file discovery via Pearcleaner or native patterns.
 
 ### `compare.py`
-`compare_reports(path1, path2) -> CompareSummary` diffs findings by stable ID. Returns new, resolved, and changed (size/reason delta) finding lists. Renders as Markdown or JSON.
+Diffs two JSON reports to show new, resolved, or changed findings.
 
 ### `export.py`
-`export_obsidian(reports_dir, vault_path)` reads the most recent JSON report, formats a frontmatter block, and appends it to today's daily note (`vault/YYYY-MM-DD.md`). Deduplicates by `generated_at` — safe to run multiple times.
+Exports scan summaries to external formats (e.g., Obsidian).
 
 ---
 
 ## tools/ — OSS Wrappers
 
-Every file in `tools/` follows the same contract:
-
-1. **Check if the tool is installed** (`shutil.which`) before calling subprocess
-2. **Return `[]` on any failure** — timeout, missing binary, parse error, daemon offline
-3. **Never raise** — degradation is always silent and logged implicitly via empty return
-4. **No inline subprocess calls outside `tools/`** — all subprocess lives here
-5. **Independently testable** — mock `subprocess.run` and `shutil.which`, never call real tools in tests
-
-### `tools/brew.py`
-
-Runs `HOMEBREW_NO_AUTO_UPDATE=1 brew cleanup --dry-run`.
-
-Output format:
-```
-Would remove: /path/to/file (3.4MB)
-Would remove: /path/to/dir (96 files, 2.7MB)
-Would remove (broken link): /path/to/symlink
-Would remove (empty directory): /path/to/dir
-==> This operation would free approximately 109.2MB of disk space.
-```
-
-Parses each `Would remove:` line with a regex. Size is extracted from the parenthetical. Summary line is ignored. All findings are `auto_safe` — brew itself determines what is safe.
-
-### `tools/disk.py`
-
-Three-tier size analysis:
-
-1. **`dua aggregate -f bytes <children...>`** — fast parallel, ANSI output stripped by regex
-2. **`du -d 1 -k <path>`** — macOS built-in, always available, kilobytes
-3. **`path_size()` from `model.py`** — pure Python rglob, slowest, last resort
-
-Children are expanded via `path.iterdir()` in Python before passing to dua (shell glob does not expand in `subprocess.run` list form).
-
-Output format (dua, after ANSI stripping):
-```
-  27406336 b  /path/to/subdir
-   8941568 b  /path/to/other
-  36347904 b  total
-```
-
-Public API: `size_of(path)`, `top_subdirs(path, n=5)`, `top_subdirs_summary(path, n=5)`.
-`top_subdirs_summary` returns a human-readable string like `"largest: Google (1.3 GB), ms-playwright (1.0 GB)"` for appending to `Finding.reason`.
-
-### `tools/docker_check.py`
-
-Runs `docker system df --format '{{json .}}'`.
-
-Output format (one JSON object per line):
-```json
-{"Active":"10","Reclaimable":"9.789GB (49%)","Size":"19.7GB","TotalCount":"52","Type":"Images"}
-```
-
-Categories: `Images`, `Containers`, `Local Volumes`, `Build Cache` → mapped to mac-care categories `docker_images`, `docker_containers`, `docker_volumes`, `docker_build_cache`.
-
-`size_bytes` is set to reclaimable bytes (not total). Findings with zero reclaimable are skipped. All Docker findings are `review` risk — never auto-cleaned.
-
-Checks daemon reachability via `docker info` before calling `docker system df`.
-
-### `tools/pearcleaner.py`
-
-Runs `pearcleaner list-orphaned`. Binary found via `which("pearcleaner")` or known app paths (`/Applications/Pearcleaner.app/Contents/MacOS/Pearcleaner`).
-
-CLI source verified from [alienator88/Pearcleaner — Logic/CLI.swift](https://github.com/alienator88/Pearcleaner/blob/main/Pearcleaner/Logic/CLI.swift). Subcommand is `list-orphaned`, output is one path per line, ends with `"Found N orphaned files."`.
-
-All findings are `review` risk — never auto-cleaned.
-
-Live validation note: Pearcleaner 5.4.3 installed via Homebrew cask and `pearcleaner --help` confirms the `list-orphaned` subcommand. On this machine, `pearcleaner list-orphaned` did not return within 60 seconds, so the wrapper timeout is part of the safety contract and should remain fail-closed to `[]`.
-
----
-
-## Report Structure
-
-### JSON report
-
-```json
-{
-  "generated_at": "2026-05-02T21:08:26",
-  "findings": [
-    {
-      "category": "brew_cache",
-      "path": "/opt/homebrew/Cellar/xz/5.8.2",
-      "size_bytes": 2700000,
-      "risk": "auto_safe",
-      "reason": "brew cleanup: safe to remove",
-      "source": "brew"
-    }
-  ],
-  "tools": [
-    {
-      "name": "brew",
-      "status": "ok",
-      "detail": "/opt/homebrew/bin/brew"
-    }
-  ]
-}
-```
-
-### Markdown report
-
-Grouped by risk level (`auto_safe` → `review` → `protected`), each group shows total size and a table sorted descending by size. Doctor section appended at the end.
+Every file in `tools/` follows a strict contract:
+1. **Check if the tool is installed** before calling subprocess.
+2. **Return `[]` on any failure** — degradation is always silent.
+3. **No inline subprocess calls outside `tools/`**.
+4. **Independently testable** via mocks.
 
 ---
 
 ## Safety Invariants
 
-These must hold at all times. Tests should catch regressions.
-
-1. `scan()` never modifies or deletes files.
-2. `safe_clean()` only acts on `risk == "auto_safe"` findings.
-3. Protected paths are checked via `safety.is_protected()` in both `scan.py` and `clean.py`; `clean.py` also re-checks the git safety gate before acting.
-4. Git safety gate returns `True` (unsafe) on any subprocess failure — never silently clears a repo.
-5. Every `tools/` wrapper returns `[]` on any error — never propagates exceptions to the caller.
-6. `dry_run=True` is the default for `safe_clean()`. Callers must explicitly pass `dry_run=False` to act.
-7. Execution moves to `quarantine_dir`, never `rm`.
-8. Review approval accepts only stable finding IDs from known reports, never arbitrary browser/CLI paths.
+1. **Dry-Run by Default**: All destructive commands default to no-op.
+2. **Quarantine First**: Items are moved to `~/.mac-care/quarantine/` with `0700` permissions.
+3. **Git Safety Gate**: Active/dirty repos are never touched.
+4. **Supply Chain Transparency**: Reports record absolute paths of every external binary invoked.
+5. **Path Drift Protection**: Actions are aborted if the filesystem has changed since the scan.
+6. **No Automated Sudo**: Elevated actions provide copy-paste guidance instead of automated execution.

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Replace the practical operational value of CleanMyMac for a developer machine with a free, local, report-first CLI tool. No polished UI clone. No surprise deletions. Integrate good OSS tools rather than rebuilding commodity scanners.
+Provide a **Developer Health Console** for macOS that offers operational visibility and safe, reversible maintenance. mac-care acts as an orchestrator, integrating trusted OSS tools rather than rebuilding commodity scanners.
 
 Repo: https://github.com/djspiceroute/mac-care  
 Stack: Python 3.11+, stdlib only (no pip runtime deps)
@@ -11,218 +11,69 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 
 ## Feature Status
 
-### ✅ Shipped
-
-| Feature | Command | Notes |
-|---|---|---|
-| Disk scan — standard paths | `mac-care scan` | Logs, caches, trash, tmp |
-| Disk scan — developer paths | `mac-care scan` | Xcode DerivedData, Gradle cache |
-| Disk scan — old installers | `mac-care scan` | Downloads: .dmg/.pkg/.zip older than `min_age_days` |
-| Codex workspace scan | `mac-care scan` | Marks as `protected` if any dirty/active git repos found |
-| Homebrew cache scan | `mac-care scan` | Via `brew cleanup --dry-run` — per-item, `auto_safe` |
-| Docker disk usage | `mac-care scan` | Via `docker system df` — reclaimable per category, `review` |
-| Orphaned app files | `mac-care scan` | Via `pearcleaner list-orphaned`, `review` (if installed) |
-| Disk tree analysis | `scan` internals | Via `dua` → `du` → Python fallback; top-subdir breakdown >500 MB |
-| Git/worktree safety gate | `scan` + `clean` | `git_safety.py`: dirty/active repo detection before any action |
-| Developer tool health | `mac-care doctor` | Required tools, Homebrew PATH, Docker daemon |
-| Tool status | `mac-care tools status` | Required + optional tools installed/missing |
-| Tool recommendations | `mac-care tools recommend` | Missing OSS tools with `brew install` hints, grouped |
-| Compact scan summary | `mac-care scan` | Counts and sizes by risk, top findings, tool warning count |
-| Scan output flags | `mac-care scan --stdout` | Print JSON or Markdown to stdout for piping; skip writing files |
-| launchd schedule | `mac-care schedule install` | Writes scan-only plist to `~/Library/LaunchAgents/`; `--dry-run` prints plist |
-| launchd uninstall | `mac-care schedule uninstall` | Removes plist and attempts launchctl unload; `--dry-run` prints planned removal |
-| Schedule interval config | `--interval <hours>` | Default 24h; uses launchd `StartInterval`; runs `mac-care scan --notify` only |
-| macOS scan notification | `mac-care scan --notify` | Posts compact scan summary through `osascript`; degrades gracefully |
-| Safe cleanup (dry-run) | `mac-care clean --safe --dry-run` | Prints `auto_safe` candidates, no deletion |
-| Quarantine cleanup execution | `mac-care clean --safe --execute` | Moves eligible `auto_safe` findings to quarantine with metadata; never `rm` |
-| Review approval flow | `mac-care review approve` | Approves one `review` finding by stable report finding ID; quarantine-only on execute |
-| Markdown + JSON + HTML reports | `mac-care scan` | Timestamped Markdown/JSON plus read-only `latest.html` in `~/.mac-care/reports/` |
-| Report history index | `mac-care scan` | Writes read-only `index.html` listing previous JSON/Markdown/dashboard reports |
-| Report rotation | `mac-care scan` | Deletes old reports; configurable `retention_days` + `retention_min_keep` |
-| Protected paths config | `config.toml` | Hardcoded defaults + user override via TOML |
-| Per-category policy | `config.toml` | `[policy.<category>]` overrides `min_age_days` per scan category |
-| Additional scan paths | `config.toml` | `additional_scan_paths` extends workspace scan beyond defaults |
-| Stable finding IDs | JSON reports | SHA-256 of `category+path+risk+source` — stable across runs |
-| iOS backups scan | `mac-care scan` | `~/Library/Application Support/MobileSync/Backup/` — `review` |
-| Messages attachments scan | `mac-care scan` | `~/Library/Messages/Attachments/` — `review` |
-| Time Machine snapshots scan | `mac-care scan` | `tmutil listlocalsnapshots /` — `review` |
-| Core dumps and crash logs | `mac-care scan` | `~/Library/Logs/DiagnosticReports/` — `review` |
-| Broken symlinks scan | `mac-care scan` | Common `~/Library/` dirs — `review` |
-| Login items scan | `mac-care scan` | `~/Library/LaunchAgents/` — lists persistent daemons as `review` |
-| Stale runtime versions | `mac-care scan` | pyenv, nvm, rbenv, sdkman, rustup orphaned versions — `review` |
-| Orphaned dot directories | `mac-care scan` | Inactive `~/.<tool>` dirs not referenced by any project — `review` |
-| AI tool caches | `mac-care scan` | Copilot, Cursor, Windsurf, Continue, Ollama model caches — `auto_safe` |
-| SSH key encryption check | `mac-care doctor` | Warns on unencrypted private keys in `~/.ssh/` |
-| Redundant toolchain check | `mac-care doctor` | Detects multiple Python/Node/Ruby/Go/Rust installations |
-| App uninstall helper | `mac-care uninstall <App>` | Support file discovery via Pearcleaner or native `~/Library/` patterns; `--execute` quarantines |
-| Privacy audit | `mac-care audit privacy` | Reads macOS TCC database; lists all permission grants by service |
-| Report compare | `mac-care compare` | Diffs two JSON reports; shows new, resolved, and changed findings |
-| Obsidian export | `mac-care export --format obsidian` | Appends scan summary to today's daily note; deduplication-safe |
-| GitHub Actions CI | `.github/workflows/test.yml` | `macos-latest`, Python 3.11, 163 tests |
-| Branch protection | GitHub | Requires CI to pass before merge to main |
-| Issue/PR templates | `.github/` | epic / story / enabler / bug + PR template |
-
----
-
----
-
-### 🗓 Future / backlog
+### 🟢 Phase 1: Foundation (Shipped)
 
 | Feature | Notes |
 |---|---|
-| `mac-care security` | KnockKnock (Objective-See) integration — launch agents, login items, browser extensions. Separate command, not part of `scan`. |
-| `mas` integration | `mas outdated` for Mac App Store update checks. |
-| Stale npm/pnpm global packages | Surface outdated global packages. |
-| `brew` outdated formulae | Surface formulae with available updates (not just cache). |
-| Xcode simulator cleanup | `xcrun simctl delete unavailable` — rebuildable, `auto_safe` candidate. |
-| Python venv orphan detection | Find `.venv` dirs whose parent project no longer exists. |
-| Large file finder | Top N largest files across home directory (excluding protected paths). |
-| Menu bar / status item | Only after engine is proven useful. SwiftUI or Tauri. |
+| **Deep Scanners** | logs, caches, trash, tmp, Xcode DerivedData, Gradle cache |
+| **OSS Integrations** | Homebrew, Docker, dua, Pearcleaner |
+| **Git Safety Gate** | Dirty/active repo detection; automatic protection of workspace paths |
+| **Tool Health** | Required tools check, SSH key encryption audit, redundant toolchain detection |
+| **Reports** | Timestamped MD + JSON; static HTML dashboard; report rotation |
+| **Safe Cleanup** | dry-run default; quarantine execution for `auto_safe` findings |
+| **Uninstall** | App support-file discovery and guided removal |
+| **Privacy Audit** | TCC database audit (requires Full Disk Access) |
+| **History/Compare** | Historical scan index and diffing between scan results |
+| **Scheduling** | launchd-backed periodic scans with macOS notifications |
+| **Export** | Obsidian daily note export |
+
+### 🟡 Phase 2: Interactive Console (In Progress)
+
+| Feature | Issue | Status |
+|---|---|---|
+| **Quarantine Management** | status, purge, and auto-rotation | #44, #45 | Planned |
+| **Security Audit** | Persistence visibility for LaunchAgents/Daemons | #54 | Planned |
+| **Xcode Dev Cleanup** | Simulator and device support cleanup | #53 | Planned |
+| **Large File Finder** | Global scanner with protected-path exclusions | #51 | Planned |
+| **Interactive TUI** | Terminal-based management console | #64 | Planned |
+| **Action Service Layer** | Reusable engine for CLI and TUI | #61 | Planned |
+| **Quarantine Restore** | Receipt-based "Undo" for cleanup | #62 | Planned |
+| **Hardening** | 0700 permissions and path anonymization | #59, #60 | Planned |
+| **Supply Chain** | Record absolute tool paths in reports | #50 | Planned |
+
+---
+
+## Security & Privacy Invariants
+
+These principles guide all development:
+
+1. **Local-Only**: No data is uploaded; all processing is on-device.
+2. **Reversibility**: Files are moved to quarantine with **0700 permissions** (#59).
+3. **Receipt-Based Audit**: Every action generates a JSON receipt for the **Restore** flow.
+4. **Supply Chain Transparency**: Resolved binary paths are pinned and recorded in reports (#50).
+5. **Guided Sudo**: Privilege escalation is never automated; mac-care provides verified commands for manual execution.
+6. **Path Anonymization**: Reports can redact home directory paths for safe sharing (#60).
+7. **Path Drift Protection**: Actions re-verify file metadata immediately before execution to prevent TOCTOU attacks (#49).
 
 ---
 
 ## OSS Tool Dependencies
 
-All are optional — mac-care degrades gracefully when absent.
-
-| Tool | Install | Used by | Notes |
-|---|---|---|---|
-| `dua` | `brew install dua-cli` | `tools/disk.py` (primary) | Fast parallel disk usage tree |
-| `dust` | `brew install dust` | `tools/disk.py` (planned secondary) | Rust-based directory size tree |
-| `gdu` | `brew install gdu` | Not integrated | Name collision with GNU `du` on machines with `coreutils` installed |
-| `ncdu` | `brew install ncdu` | Not integrated | Interactive ncurses disk usage |
-| `pearcleaner` | `brew install --cask pearcleaner` | `tools/pearcleaner.py` | CLI verified; `list-orphaned` timed out live |
-| `mas` | `brew install mas` | Not yet integrated | Mac App Store CLI |
-| KnockKnock | Manual download (Objective-See) | Planned `mac-care security` | Security persistence scanner |
-
----
-
-## Protected Paths (Defaults)
-
-Defined in `src/mac_care/config.py:DEFAULT_PROTECTED_PATHS`. Never auto-cleaned regardless of risk level. Override entirely via `protected_paths` in `config.toml`.
-
-Key categories protected by default:
-- VS Code extensions
-- Browser native messaging hosts (Chrome, Firefox)
-- `~/.ssh`
-- Any directory containing an active or dirty git repo (checked dynamically at runtime)
+| Tool | Usage | Risk Level |
+|---|---|---|
+| `dua` | Fast disk usage trees | `native/dua` |
+| `brew` | Package cache cleanup | `auto_safe` |
+| `docker` | Container/Image management | `review` |
+| `pearcleaner` | Orphaned app file discovery | `review` |
 
 ---
 
 ## Known Constraints
 
-- **Quarantine execution is intentionally narrow.** `mac-care clean --safe --execute` moves eligible `auto_safe` findings to quarantine, but broad container findings such as `user_caches`, `user_logs`, `trash`, and `tmp` are skipped until scan itemizes their contents.
-- **`gdu` name collision.** `brew install coreutils` puts a `gdu` binary on PATH that is GNU `du`, not the Go disk usage analyzer. `tools/disk.py` uses `dua` as primary — `gdu` integration is deferred until resolved (possible fix: fingerprint binary via `--help` output before use).
-- **Pearcleaner live constraint.** Pearcleaner 5.4.3 installed successfully via Homebrew cask and linked `/opt/homebrew/bin/pearcleaner`. `pearcleaner --help` confirms `list-orphaned`, but the real `pearcleaner list-orphaned` call did not return within 60 seconds on this machine. The wrapper's timeout path returned `[]` as intended, so scans stay responsive and Pearcleaner findings remain optional/review-only.
-- **No scan output format flags yet.** `mac-care scan` always writes both files. `--stdout --format json/markdown` is in progress (issue #6).
-- **Interactive notification actions are not implemented.** Notifications summarize the scan only; review still happens in reports.
-
----
-
-## Test Coverage
-
-163 tests, all passing. Runtime: ~0.3s locally, ~14s on `macos-latest` CI.
-
-| Test file | Coverage |
-|---|---|
-| `tests/test_clean.py` | Dry-run default, quarantine moves, metadata, protected-path re-check, non-itemized skip |
-| `tests/test_cli.py` | Scan stdout JSON/Markdown and default report-writing command behavior |
-| `tests/test_compare.py` | New/resolved/changed finding diff, zero-size reason diff, JSON/Markdown render |
-| `tests/test_export.py` | Obsidian daily note creation, deduplication, missing reports error |
-| `tests/test_history.py` | Report history loading, malformed report skipping, index rendering/writing |
-| `tests/test_ids.py` | Stable finding ID behavior; reason/size exclusion; risk-change stability |
-| `tests/test_notification.py` | Notification text and graceful `osascript` delivery behavior |
-| `tests/test_safety.py` | `is_protected()` — protected paths, quarantine dir, non-protected paths |
-| `tests/test_scan.py` | All new scan functions: iOS backups, Messages, Time Machine, crash logs, broken symlinks, login items, stale runtimes, orphaned dotdirs, AI tool caches |
-| `tests/test_scheduler.py` | launchd plist rendering, bootstrap activation, dry-run install/uninstall, plist write/remove |
-| `tests/test_report.py` | Markdown/JSON/HTML rendering, risk grouping, read-only dashboard guard, rotation |
-| `tests/test_review.py` | Review approval dry-run, quarantine execution, protected/unknown finding rejection |
-| `tests/test_summary.py` | Risk totals, top findings, tool warning count |
-| `tests/test_git_safety.py` | `find_git_repos`, `is_dirty`, `has_active_worktrees`, `unsafe_repos` — all degradation paths |
-| `tests/test_doctor.py` | `recommend_tools`, SSH key encryption check, redundant toolchain detection |
-| `tests/tools/test_brew.py` | `_parse_size`, full parse, sizes, risk/source tagging, all degradation |
-| `tests/tools/test_disk.py` | dua path, du fallback, `size_of`, nonexistent, summary format |
-| `tests/tools/test_docker.py` | `_parse_docker_size`, 4-category parse, reclaimable sizes, hints, degradation |
-| `tests/tools/test_pearcleaner.py` | `_guess_app_name`, path parse, summary line skip, risk/source, degradation |
-
-**Testing rules (must be maintained):**
-- Tests never touch the real filesystem — use `tmp_path`
-- Tests never call real external tools — mock all `subprocess.run` calls
-- Mock target is always the module's own import (e.g. `mac_care.doctor.which`, not `shutil.which`)
-- Every new `tools/` module must have at least one degradation test (tool missing, timeout, OSError)
-
----
-
-## Example scan output shape
-
-Reports include a reusable compact summary used by CLI output and intended for future HTML reports and notifications:
-
-```json
-{
-  "summary": {
-    "risks": {
-      "auto_safe": {"count": 12, "size_bytes": 109000000},
-      "review": {"count": 4, "size_bytes": 9800000000},
-      "protected": {"count": 1, "size_bytes": 3200000000}
-    },
-    "top_findings": [],
-    "tool_warning_count": 2
-  }
-}
-```
-
-JSON report findings also include stable IDs used for review approval. The ID is a 16-character hex prefix of `SHA-256(category + "\0" + path + "\0" + risk + "\0" + source)`. `reason` and `size_bytes` are intentionally excluded so IDs remain stable across scans even when subdirectory sizes change:
-
-```json
-{
-  "findings": [
-    {
-      "id": "3b6d0f0d9a8c1e2f",
-      "category": "orphaned_app_files",
-      "path": "/Users/you/Library/Application Support/Zoom",
-      "risk": "review",
-      "source": "pearcleaner"
-    }
-  ]
-}
-```
-
-Pipe-friendly scan output skips file writing and emits a single report format:
-
-```bash
-mac-care scan --stdout --format json
-mac-care scan --stdout --format markdown
-```
-
-Default scan writes `latest.html` as a static local dashboard alongside timestamped Markdown and JSON reports. The HTML is read-only by design: it summarizes findings, risk groups, top findings, and doctor output, but does not include cleanup action controls.
-
-Periodic scan scheduling is launchd-based and scan-only:
-
-```bash
-mac-care schedule install --dry-run
-mac-care schedule install --interval 24
-mac-care schedule uninstall --dry-run
-mac-care schedule uninstall
-```
-
-Scheduled scans use `mac-care scan --notify`, which writes reports and posts a compact macOS notification. Notification delivery failures are ignored so scan/report generation still succeeds.
-
-Each default scan also updates `index.html` in the reports directory. The index is read-only and lists historical JSON/Markdown/dashboard reports in reverse chronological order, skipping malformed JSON reports safely.
-
-| Source | Category examples | Risk |
-|---|---|---|
-| Homebrew | Per-item stale formulae, old downloads | `auto_safe` |
-| Docker | Images, build cache, volumes, containers | `review` |
-| Disk | Xcode DerivedData, Gradle cache, user caches | `auto_safe` / `review` |
-| Disk (enriched) | Top subdirs listed in reason for dirs >500 MB | — |
-| Downloads | Old .dmg / .pkg / .zip past `min_age_days` | `review` |
-| Pearcleaner | Orphaned app support paths (uninstall command) | `review` |
-| Git workspaces | Any workspace with active/dirty repos | `protected` |
-| Native (scan.py) | iOS backups, Messages attachments, Time Machine snapshots | `review` |
-| Native (scan.py) | Core dumps, crash logs, broken symlinks, login items | `review` |
-| Native (scan.py) | Stale runtime versions (pyenv/nvm/rbenv/sdkman/rustup) | `review` |
-| Native (scan.py) | Orphaned dot directories | `review` |
-| Native (scan.py) | AI tool caches (Copilot, Cursor, Ollama, etc.) | `auto_safe` |
+- **Full Disk Access (FDA)**: Required for auditing Messages attachments, Mail, and TCC databases. Users must grant this via System Settings.
+- **Python Runtime**: Requires 3.11+. No external `pip` dependencies are permitted for the core runtime to ensure zero-overhead installation.
+- **TUI > Web UI**: For developer workflows, a Terminal UI is preferred over a local web server to minimize security surface area and context switching.
+- **Fail-Safe Git**: If the `git` binary is missing or a repo check fails, the path is always treated as `protected`.
 
 ---
 
@@ -230,13 +81,10 @@ Each default scan also updates `index.html` in the reports directory. The index 
 
 | Date | Decision | Rationale |
 |---|---|---|
-| 2026-05-01 | Python CLI first, not SwiftUI | Get the engine working before any UI investment |
-| 2026-05-01 | Report-first, no deletion by default | Primary value is visibility, not automation |
-| 2026-05-01 | OSS orchestrator pattern | Trust brew/docker/dua output over reimplementing their logic |
-| 2026-05-02 | `dua` as disk primary, `du` as fallback | dua is fast and parallel; du is always available; both parse cleanly |
-| 2026-05-02 | `gdu` integration deferred | Name collision with GNU du — needs binary fingerprinting before use |
-| 2026-05-02 | Docker findings all `review` | Docker cleanup is stateful and non-trivial; always require user intent |
-| 2026-05-02 | Pearcleaner all `review` | Orphaned file determination is heuristic; human confirmation is necessary |
-| 2026-05-02 | Keep Pearcleaner timeout degradation | Live `list-orphaned` can hang; wrapper should return `[]` rather than block scan |
-| 2026-05-02 | Quarantine dir instead of `rm` | One-way door prevention; files can be recovered from quarantine |
-| 2026-05-02 | Repo made public | Enables GitHub Actions CI and branch protection on free tier |
+| 2026-05-01 | Python CLI first | Get the engine working before any UI investment. |
+| 2026-05-01 | Report-first | Primary value is visibility, not automation. |
+| 2026-05-02 | Quarantine over rm | One-way door prevention; enable recovery. |
+| 2026-05-03 | TUI over Web UI | Minimize security footprint; stay in dev workflow. |
+| 2026-05-03 | Lightweight Pulses | Avoid CPU/battery drain of real-time file watchers. |
+| 2026-05-03 | 0700 Quarantine | Prevent local snooping on quarantined sensitive files. |
+| 2026-05-03 | Action Service Layer | Enable multiple interfaces (CLI/TUI) to share safety logic. |


### PR DESCRIPTION
Updates mac-care to reflect its Phase 2 evolution into a Developer Health Console.

Key changes:
- README: Pivot to Developer Health Console vision and security/privacy boundaries.
- Architecture: Document Action Service Layer, State Store, and Restore flow.
- Tech Spec: Formalize security/privacy invariants and Phase 2 status.
- AGENTS: Add GitNexus code intelligence instructions.
- .gemini.md: Project-specific agent instructions.

Closes #48