### PR TITLE
refactor(clean): extract action service layer

### DIFF
--- a/src/mac_care/actions.py
+++ b/src/mac_care/actions.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+import shutil
+import uuid
+
+from .config import Config
+from .git_safety import unsafe_repos
+from .model import Finding
+from .safety import is_protected
+
+# Categories whose paths may contain git repos — always re-check before acting.
+WORKSPACE_CATEGORIES = {"codex_workspaces"}
+
+# First execution path only supports item-level or rebuildable directory moves.
+# Broad containers like ~/Library/Caches and /tmp stay dry-run-only until scan
+# itemizes their contents.
+EXECUTABLE_AUTO_SAFE_CATEGORIES = {"brew_cache", "xcode_derived_data"}
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    action: str
+    category: str
+    path: str
+    status: str
+    message: str
+    destination: str | None = None
+    size_bytes: int = 0
+
+    def render(self) -> str:
+        if self.status == "would_clean":
+            return f"would clean {self.category}: {self.path}"
+        if self.status == "quarantined" and self.destination:
+            return f"quarantined {self.category}: {self.path} -> {self.destination}"
+        if self.status == "purged":
+            return f"purged {self.category}: {self.path}"
+        return self.message
+
+
+def preview_clean_action(finding: Finding, config: Config | None = None) -> ActionResult:
+    if finding.risk != "auto_safe":
+        return ActionResult(
+            action="clean",
+            category=finding.category,
+            path=finding.path,
+            status="skipped",
+            message=f"skipped {finding.category}: finding risk is {finding.risk}",
+            size_bytes=finding.size_bytes,
+        )
+    blocked = _safety_skip(finding, config)
+    if blocked:
+        return blocked
+    return ActionResult(
+        action="clean",
+        category=finding.category,
+        path=finding.path,
+        status="would_clean",
+        message=f"would clean {finding.category}: {finding.path}",
+        size_bytes=finding.size_bytes,
+    )
+
+
+def preview_quarantine_action(finding: Finding, config: Config | None = None) -> ActionResult:
+    if finding.risk == "protected":
+        return ActionResult(
+            action="quarantine",
+            category=finding.category,
+            path=finding.path,
+            status="skipped",
+            message=f"skipped review approval: protected findings cannot be actioned",
+            size_bytes=finding.size_bytes,
+        )
+    blocked = _safety_skip(finding, config)
+    if blocked:
+        return blocked
+    return ActionResult(
+        action="quarantine",
+        category=finding.category,
+        path=finding.path,
+        status="would_quarantine",
+        message=f"would quarantine {finding.risk} finding: {finding.path}",
+        size_bytes=finding.size_bytes,
+    )
+
+
+def quarantine_action(finding: Finding, config: Config, run_id: str | None = None) -> ActionResult:
+    blocked = _safety_skip(finding, config)
+    if blocked:
+        return blocked
+
+    if finding.category not in EXECUTABLE_AUTO_SAFE_CATEGORIES and finding.risk == "auto_safe":
+        return ActionResult(
+            action="quarantine",
+            category=finding.category,
+            path=finding.path,
+            status="skipped",
+            message=f"skipped execution for {finding.category}: category is not itemized for quarantine yet",
+            size_bytes=finding.size_bytes,
+        )
+
+    path = Path(finding.path).expanduser()
+    if not path.exists():
+        return ActionResult(
+            action="quarantine",
+            category=finding.category,
+            path=str(path),
+            status="skipped",
+            message=f"skipped execution for {finding.category}: path no longer exists {path}",
+            size_bytes=finding.size_bytes,
+        )
+
+    run_id = run_id or datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    destination = _quarantine_path(config, finding, run_id)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(path), str(destination))
+    _write_metadata(destination.parent, destination, finding)
+    return ActionResult(
+        action="quarantine",
+        category=finding.category,
+        path=str(path),
+        status="quarantined",
+        message=f"quarantined {finding.category}: {path} -> {destination}",
+        destination=str(destination),
+        size_bytes=finding.size_bytes,
+    )
+
+
+def purge_action(finding: Finding, config: Config | None = None) -> ActionResult:
+    blocked = _safety_skip(finding, config)
+    if blocked:
+        return blocked
+
+    if finding.category not in EXECUTABLE_AUTO_SAFE_CATEGORIES:
+        return ActionResult(
+            action="purge",
+            category=finding.category,
+            path=finding.path,
+            status="skipped",
+            message=f"skipped purge for {finding.category}: category is not itemized for permanent deletion yet",
+            size_bytes=finding.size_bytes,
+        )
+
+    path = Path(finding.path).expanduser()
+    if not path.exists():
+        return ActionResult(
+            action="purge",
+            category=finding.category,
+            path=str(path),
+            status="skipped",
+            message=f"skipped {finding.category}: path no longer exists {path}",
+            size_bytes=finding.size_bytes,
+        )
+    try:
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+    except OSError as e:
+        return ActionResult(
+            action="purge",
+            category=finding.category,
+            path=str(path),
+            status="failed",
+            message=f"failed to purge {finding.category}: {path} — {e}",
+            size_bytes=finding.size_bytes,
+        )
+
+    return ActionResult(
+        action="purge",
+        category=finding.category,
+        path=str(path),
+        status="purged",
+        message=f"purged {finding.category}: {path}",
+        size_bytes=finding.size_bytes,
+    )
+
+
+def _safety_skip(finding: Finding, config: Config | None) -> ActionResult | None:
+    path = Path(finding.path).expanduser()
+
+    if finding.category in WORKSPACE_CATEGORIES:
+        dirty = unsafe_repos(path)
+        if dirty:
+            return ActionResult(
+                action="skip",
+                category=finding.category,
+                path=str(path),
+                status="skipped",
+                message=(
+                    f"skipped {finding.category}: unsafe git repos detected at execution time — "
+                    f"{', '.join(str(r) for r in dirty[:2])}"
+                ),
+                size_bytes=finding.size_bytes,
+            )
+
+    if config and is_protected(path, config):
+        return ActionResult(
+            action="skip",
+            category=finding.category,
+            path=str(path),
+            status="skipped",
+            message=f"skipped {finding.category}: protected path {path}",
+            size_bytes=finding.size_bytes,
+        )
+
+    return None
+
+
+def _quarantine_path(config: Config, finding: Finding, run_id: str) -> Path:
+    base = config.quarantine_dir.expanduser() / run_id / finding.category
+    source = Path(finding.path)
+    name = source.name or finding.category
+    candidate = base / name
+    if not candidate.exists():
+        return candidate
+    return base / f"{name}-{uuid.uuid4().hex[:8]}"
+
+
+def _write_metadata(run_dir: Path, destination: Path, finding: Finding) -> None:
+    metadata = {
+        "original_path": finding.path,
+        "quarantine_path": str(destination),
+        "category": finding.category,
+        "risk": finding.risk,
+        "source": finding.source,
+        "reason": finding.reason,
+        "size_bytes": finding.size_bytes,
+        "quarantined_at": datetime.now().isoformat(timespec="seconds"),
+    }
+    metadata_path = run_dir / f"{destination.name}.metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")

--- a/src/mac_care/clean.py
+++ b/src/mac_care/clean.py
@@ -1,23 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-import json
-from pathlib import Path
-import shutil
-import uuid
 
+from .actions import preview_clean_action, purge_action, quarantine_action
 from .config import Config
-from .git_safety import unsafe_repos
 from .model import Finding
-from .safety import is_protected
-
-# Categories whose paths may contain git repos — always re-check before acting.
-_WORKSPACE_CATEGORIES = {"codex_workspaces"}
-
-# First execution path only supports item-level or rebuildable directory moves.
-# Broad containers like ~/Library/Caches and /tmp stay dry-run-only until scan
-# itemizes their contents.
-_EXECUTABLE_AUTO_SAFE_CATEGORIES = {"brew_cache", "xcode_derived_data"}
 
 
 def safe_clean(
@@ -32,29 +19,12 @@ def safe_clean(
         if finding.risk != "auto_safe":
             continue
 
-        path = Path(finding.path).expanduser()
-
-        # Re-run git safety gate for workspace-adjacent categories even if
-        # scan already marked them auto_safe (belt-and-suspenders guard).
-        if finding.category in _WORKSPACE_CATEGORIES:
-            dirty = unsafe_repos(path)
-            if dirty:
-                actions.append(
-                    f"skipped {finding.category}: unsafe git repos detected at scan time — "
-                    f"{', '.join(str(r) for r in dirty[:2])}"
-                )
-                continue
-
-        if config and is_protected(path, config):
-            actions.append(f"skipped {finding.category}: protected path {path}")
-            continue
-
         if dry_run:
-            actions.append(f"would clean {finding.category}: {finding.path}")
+            actions.append(preview_clean_action(finding, config).render())
             continue
 
         if purge:
-            actions.append(_purge_finding(finding))
+            actions.append(purge_action(finding, config).render())
             continue
 
         if config is None:
@@ -63,75 +33,13 @@ def safe_clean(
             )
             continue
 
-        if finding.category not in _EXECUTABLE_AUTO_SAFE_CATEGORIES:
-            actions.append(
-                f"skipped execution for {finding.category}: category is not itemized for quarantine yet"
-            )
-            continue
-
-        actions.append(quarantine_finding(finding, config, run_id=run_id))
+        actions.append(quarantine_action(finding, config, run_id=run_id).render())
     return actions
 
 
 def _purge_finding(finding: Finding) -> str:
-    path = Path(finding.path).expanduser()
-    if not path.exists():
-        return f"skipped {finding.category}: path no longer exists {path}"
-    try:
-        if path.is_dir():
-            shutil.rmtree(path)
-        else:
-            path.unlink()
-        return f"purged {finding.category}: {path}"
-    except OSError as e:
-        return f"failed to purge {finding.category}: {path} — {e}"
+    return purge_action(finding).render()
 
 
 def quarantine_finding(finding: Finding, config: Config, run_id: str | None = None) -> str:
-    run_id = run_id or datetime.now().strftime("%Y-%m-%d-%H%M%S")
-    path = Path(finding.path).expanduser()
-    if is_protected(path, config):
-        return f"skipped execution for {finding.category}: protected path {path}"
-
-    if finding.category in _WORKSPACE_CATEGORIES:
-        dirty = unsafe_repos(path)
-        if dirty:
-            return (
-                f"skipped {finding.category}: unsafe git repos detected at execution time — "
-                f"{', '.join(str(r) for r in dirty[:2])}"
-            )
-
-    if not path.exists():
-        return f"skipped execution for {finding.category}: path no longer exists {path}"
-
-    destination = _quarantine_path(config, finding, run_id)
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(path), str(destination))
-    _write_metadata(destination.parent, destination, finding)
-    return f"quarantined {finding.category}: {path} -> {destination}"
-
-
-
-def _quarantine_path(config: Config, finding: Finding, run_id: str) -> Path:
-    base = config.quarantine_dir.expanduser() / run_id / finding.category
-    source = Path(finding.path)
-    name = source.name or finding.category
-    candidate = base / name
-    if not candidate.exists():
-        return candidate
-    return base / f"{name}-{uuid.uuid4().hex[:8]}"
-
-
-def _write_metadata(run_dir: Path, destination: Path, finding: Finding) -> None:
-    metadata = {
-        "original_path": finding.path,
-        "quarantine_path": str(destination),
-        "category": finding.category,
-        "risk": finding.risk,
-        "source": finding.source,
-        "reason": finding.reason,
-        "size_bytes": finding.size_bytes,
-        "quarantined_at": datetime.now().isoformat(timespec="seconds"),
-    }
-    metadata_path = run_dir / f"{destination.name}.metadata.json"
-    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return quarantine_action(finding, config, run_id=run_id).render()

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -211,7 +211,7 @@ def main() -> int:
         return 0
 
     if args.command == "clean":
-        output = sys.stderr if args.stdout else sys.stdout
+        output = sys.stdout
 
         if args.purge:
             auto_safe = [f for f in findings if f.risk == "auto_safe"]

--- a/src/mac_care/review.py
+++ b/src/mac_care/review.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from .clean import quarantine_finding
+from .actions import preview_quarantine_action, quarantine_action
 from .config import Config
 from .ids import finding_id
 from .model import Finding
@@ -20,9 +20,12 @@ def approve_finding(report_path: Path, finding_id_value: str, config: Config, dr
         return f"skipped review approval for {finding_id_value}: finding risk is {finding.risk}, not review"
 
     if dry_run:
-        return f"would quarantine review finding {finding_id_value}: {finding.path}"
+        result = preview_quarantine_action(finding, config)
+        if result.status == "would_quarantine":
+            return f"would quarantine review finding {finding_id_value}: {finding.path}"
+        return result.render()
 
-    return quarantine_finding(finding, config)
+    return quarantine_action(finding, config).render()
 
 
 def _finding_from_report(report_path: Path, finding_id_value: str) -> Finding | None:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,100 @@
+from mac_care.actions import preview_clean_action, preview_quarantine_action, purge_action, quarantine_action
+from mac_care.config import Config
+from mac_care.model import Finding
+
+
+def test_preview_action_returns_structured_result(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+
+    result = preview_clean_action(finding)
+
+    assert result.status == "would_clean"
+    assert result.render() == f"would clean brew_cache: {target}"
+    assert target.exists()
+
+
+def test_quarantine_action_moves_file_and_records_destination(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+
+    result = quarantine_action(finding, config, run_id="run-1")
+
+    assert result.status == "quarantined"
+    assert result.destination == str(config.quarantine_dir / "run-1" / "brew_cache" / "cache-item")
+    assert result.render() == f"quarantined brew_cache: {target} -> {result.destination}"
+    assert not target.exists()
+
+
+def test_preview_quarantine_action_supports_review_findings(tmp_path):
+    target = tmp_path / "orphan"
+    target.write_text("data", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("orphaned_app_files", str(target), 4, "review", "orphan", "pearcleaner")
+
+    result = preview_quarantine_action(finding, config)
+
+    assert result.status == "would_quarantine"
+    assert result.render() == f"would quarantine review finding: {target}"
+    assert target.exists()
+
+
+def test_quarantine_action_skips_protected_path(tmp_path):
+    protected = tmp_path / "protected"
+    protected.mkdir()
+    target = protected / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(
+        reports_dir=tmp_path / "reports",
+        quarantine_dir=tmp_path / "quarantine",
+        protected_paths=[protected],
+    )
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+
+    result = quarantine_action(finding, config)
+
+    assert result.status == "skipped"
+    assert result.render() == f"skipped brew_cache: protected path {target}"
+    assert target.exists()
+
+
+def test_quarantine_action_skips_non_itemized_auto_safe_category(tmp_path):
+    target = tmp_path / "Caches"
+    target.mkdir()
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("user_caches", str(target), 5, "auto_safe", "broad cache directory")
+
+    result = quarantine_action(finding, config)
+
+    assert result.status == "skipped"
+    assert result.render() == "skipped execution for user_caches: category is not itemized for quarantine yet"
+    assert target.exists()
+
+
+def test_purge_action_deletes_executable_auto_safe_file(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+
+    result = purge_action(finding)
+
+    assert result.status == "purged"
+    assert result.render() == f"purged brew_cache: {target}"
+    assert not target.exists()
+
+
+def test_purge_action_skips_non_itemized_auto_safe_category(tmp_path):
+    target = tmp_path / "Caches"
+    target.mkdir()
+    (target / "cache-file").write_text("cache", encoding="utf-8")
+    finding = Finding("user_caches", str(target), 5, "auto_safe", "broad cache directory")
+
+    result = purge_action(finding)
+
+    assert result.status == "skipped"
+    assert result.render() == "skipped purge for user_caches: category is not itemized for permanent deletion yet"
+    assert target.exists()
+    assert (target / "cache-file").exists()

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -99,6 +99,24 @@ def test_safe_clean_skips_non_itemized_auto_safe_categories(tmp_path):
     assert target.exists()
 
 
+def test_purge_skips_non_itemized_auto_safe_categories(tmp_path):
+    target = tmp_path / "Caches"
+    target.mkdir()
+    (target / "cache-file").write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    actions = safe_clean(
+        [Finding("user_caches", str(target), 5, "auto_safe", "broad cache directory")],
+        config=config,
+        dry_run=False,
+        purge=True,
+    )
+
+    assert actions == ["skipped purge for user_caches: category is not itemized for permanent deletion yet"]
+    assert target.exists()
+    assert (target / "cache-file").exists()
+
+
 def test_purge_deletes_file(tmp_path):
     target = tmp_path / "cache-item"
     target.write_text("cache", encoding="utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,3 +98,17 @@ def test_review_approve_dry_run(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "would quarantine review finding abc" in output
     assert "Dry run only" in output
+
+
+def test_clean_purge_abort(monkeypatch, capsys):
+    monkeypatch.setattr(cli.Config, "load", lambda _: object())
+    monkeypatch.setattr(cli, "scan", lambda _: [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs")])
+    monkeypatch.setattr(cli, "check_tools", lambda: [])
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    monkeypatch.setattr("sys.argv", ["mac-care", "clean", "--safe", "--purge"])
+
+    assert cli.main() == 0
+
+    output = capsys.readouterr().out
+    assert "About to permanently delete 1 auto_safe findings" in output
+    assert "Aborted." in output


### PR DESCRIPTION
## Summary
- Extract cleanup and review action execution into a structured `mac_care.actions` service layer.
- Keep existing `safe_clean()` and `quarantine_finding()` compatibility wrappers while routing through the new service.
- Add action-service coverage for preview, quarantine, purge, protected paths, and non-itemized category skips.
- Fix `clean --safe --purge` output routing so the command no longer references scan-only `args.stdout`.

## Validation
- `PYTHONPATH=src /Users/deepankarjoshi/Developer/mac-care/.venv/bin/python -m pytest tests/ -q`
- `175 passed`

## Notes
- This is the foundation for #61; restore/action receipts remain separate follow-up issues.
