### PR TITLE
fix(uninstall): validate app bundle before privileged guidance

### DIFF
--- a/src/mac_care/uninstall.py
+++ b/src/mac_care/uninstall.py
@@ -9,6 +9,9 @@ from .config import Config
 from .model import Finding, format_bytes, path_size
 from .tools.pearcleaner import _pearcleaner_bin
 
+# Order matters: resolve() resolves symlinks, so we compare against resolved bases
+_DEFAULT_APP_BASES: tuple[Path, ...] = (Path("/Applications"), Path.home() / "Applications")
+
 
 @dataclass
 class UninstallResult:
@@ -30,6 +33,45 @@ def find_app(name: str) -> Path | None:
                 if item.suffix == ".app" and item.stem.lower() == name.lower():
                     return item
     return None
+
+
+def validate_app_bundle(
+    app_path: Path, *, allowed_bases: tuple[Path, ...] = _DEFAULT_APP_BASES
+) -> bool:
+    """Validate that *app_path* is a real, trusted macOS app bundle.
+
+    Checks:
+        - exists
+        - resolves to a path under one of *allowed_bases*
+        - name ends with ``.app``
+        - is a directory (not a symlink or file)
+        - contains ``Contents/Info.plist``
+    """
+    if not app_path.exists():
+        return False
+
+    resolved = app_path.resolve()
+
+    # Must be under an allowed base directory
+    if not any(
+        resolved == base.resolve() or base.resolve() in resolved.parents
+        for base in allowed_bases
+    ):
+        return False
+
+    # Must look like a bundle
+    if not resolved.name.endswith(".app"):
+        return False
+
+    # Must be a real directory, not a symlink
+    if app_path.is_symlink():
+        return False
+
+    # Must contain the canonical plist
+    if not (resolved / "Contents" / "Info.plist").exists():
+        return False
+
+    return True
 
 
 def discover_support_files(app_path: Path) -> list[Finding]:
@@ -131,10 +173,28 @@ def _read_bundle_id(app_path: Path) -> str | None:
         return None
 
 
-def app_deletion_hint(app_path: Path) -> str:
-    """Return an appropriate deletion hint based on actual write permissions."""
+def app_deletion_hint(
+    app_path: Path | None, *, allowed_bases: tuple[Path, ...] = _DEFAULT_APP_BASES
+) -> str:
+    """Return an appropriate deletion hint based on actual write permissions.
+
+    Privileged removal guidance is shown ONLY after the app bundle passes
+    strict validation (validate_app_bundle). Untrusted or invalid paths
+    never receive sudo guidance.
+    """
+    if app_path is None:
+        return ""
+
+    if not validate_app_bundle(app_path, allowed_bases=allowed_bases):
+        return (
+            f"App bundle validation failed for '{app_path}'.\n"
+            "  Privileged removal guidance is hidden for unverified paths.\n"
+            "  Remove the app manually via Finder if appropriate."
+        )
+
     if os.access(app_path, os.W_OK):
         return f"You own this app — to remove it: trash '{app_path}'"
+
     return (
         f"This app requires elevated permissions to remove:\n"
         f"  sudo rm -rf '{app_path}'\n"

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,159 @@
+from pathlib import Path
+
+import pytest
+
+from mac_care.uninstall import (
+    UninstallResult,
+    app_deletion_hint,
+    render_uninstall_report,
+    validate_app_bundle,
+)
+
+
+def _make_valid_app_bundle(tmp_path: Path, name: str = "TestApp") -> Path:
+    """Helper: create a real-looking .app bundle under tmp_path/Applications."""
+    app_dir = tmp_path / "Applications"
+    app_dir.mkdir()
+    bundle = app_dir / f"{name}.app"
+    contents = bundle / "Contents"
+    contents.mkdir(parents=True)
+    plist = contents / "Info.plist"
+    # minimal binary-plist with CFBundleIdentifier
+    import plistlib
+    plist.write_bytes(plistlib.dumps({"CFBundleIdentifier": f"com.example.{name.lower()}"}))
+    return bundle
+
+
+# -- validate_app_bundle --
+
+
+def test_validate_app_bundle_valid(tmp_path):
+    app = _make_valid_app_bundle(tmp_path)
+    assert validate_app_bundle(app, allowed_bases=(tmp_path / "Applications",))
+
+
+def test_validate_app_bundle_missing_info_plist(tmp_path):
+    app_dir = tmp_path / "Applications"
+    app_dir.mkdir()
+    bundle = app_dir / "NoPlist.app"
+    bundle.mkdir()
+    (bundle / "Contents").mkdir()
+    assert not validate_app_bundle(bundle, allowed_bases=(app_dir,))
+
+
+def test_validate_app_bundle_is_symlink(tmp_path):
+    app_dir = tmp_path / "Applications"
+    app_dir.mkdir()
+    real_bundle = app_dir / "RealApp.app"
+    real_bundle.mkdir()
+    (real_bundle / "Contents").mkdir()
+    plist = real_bundle / "Contents" / "Info.plist"
+    import plistlib
+    plist.write_bytes(plistlib.dumps({"CFBundleIdentifier": "com.example.real"}))
+
+    symlink = app_dir / "LinkApp.app"
+    symlink.symlink_to(real_bundle)
+    assert not validate_app_bundle(symlink, allowed_bases=(app_dir,))
+
+
+def test_validate_app_bundle_not_in_allowed_bases(tmp_path):
+    app = _make_valid_app_bundle(tmp_path)
+    # Pass a different allowed base that is NOT the parent of the bundle
+    other = tmp_path / "Other"
+    other.mkdir()
+    assert not validate_app_bundle(app, allowed_bases=(other,))
+
+
+def test_validate_app_bundle_not_app_suffix(tmp_path):
+    app_dir = tmp_path / "Applications"
+    app_dir.mkdir()
+    bad = app_dir / "NotAnApp"
+    bad.mkdir()
+    assert not validate_app_bundle(bad, allowed_bases=(app_dir,))
+
+
+def test_validate_app_bundle_does_not_exist(tmp_path):
+    ghost = tmp_path / "Applications" / "Ghost.app"
+    assert not validate_app_bundle(ghost, allowed_bases=(tmp_path / "Applications",))
+
+
+# -- app_deletion_hint --
+
+
+def test_app_deletion_hint_none_app_path():
+    assert app_deletion_hint(None) == ""
+
+
+def test_app_deletion_hint_unvalidated_path_shows_no_privilege_guidance(tmp_path):
+    bad = tmp_path / "usr" / "local" / "Fake.app"
+    bad.mkdir(parents=True)
+    (bad / "Contents").mkdir()
+    import plistlib
+    (bad / "Contents" / "Info.plist").write_bytes(plistlib.dumps({"CFBundleIdentifier": "x"}))
+    hint = app_deletion_hint(bad)
+    assert "Privileged removal guidance is hidden" in hint
+
+
+def test_app_deletion_hint_valid_writable_provides_trash_hint(tmp_path, monkeypatch):
+    app = _make_valid_app_bundle(tmp_path)
+    base = tmp_path / "Applications"
+    monkeypatch.setattr("mac_care.uninstall.os.access", lambda p, _: True)
+    hint = app_deletion_hint(app, allowed_bases=(base,))
+    assert "trash" in hint
+    assert "sudo" not in hint
+
+
+def test_app_deletion_hint_valid_non_writable_provides_sudo_hint(tmp_path, monkeypatch):
+    app = _make_valid_app_bundle(tmp_path)
+    base = tmp_path / "Applications"
+    monkeypatch.setattr("mac_care.uninstall.os.access", lambda p, _: False)
+    hint = app_deletion_hint(app, allowed_bases=(base,))
+    assert "sudo rm -rf" in hint
+    assert "Double-check the path" in hint
+
+
+# -- render_uninstall_report (integration) --
+
+
+def test_render_uninstall_report_with_validated_app_sudo_hint(tmp_path, monkeypatch):
+    app = _make_valid_app_bundle(tmp_path)
+    base = tmp_path / "Applications"
+    monkeypatch.setattr("mac_care.uninstall.os.access", lambda p, _: False)
+    result = UninstallResult(
+        app_path=app,
+        support_files=[],
+        app_hint=app_deletion_hint(app, allowed_bases=(base,)),
+    )
+    report = render_uninstall_report(result)
+    assert "sudo rm -rf" in report
+    assert "App bundle validation failed" not in report
+
+
+def test_render_uninstall_report_with_validated_app_trash_hint(tmp_path, monkeypatch):
+    app = _make_valid_app_bundle(tmp_path)
+    base = tmp_path / "Applications"
+    monkeypatch.setattr("mac_care.uninstall.os.access", lambda p, _: True)
+    result = UninstallResult(
+        app_path=app,
+        support_files=[],
+        app_hint=app_deletion_hint(app, allowed_bases=(base,)),
+    )
+    report = render_uninstall_report(result)
+    assert "trash" in report
+    assert "sudo" not in report
+
+
+def test_render_uninstall_report_with_invalidated_app_hides_sudo(tmp_path):
+    bad = tmp_path / "usr" / "local" / "Fake.app"
+    bad.mkdir(parents=True)
+    (bad / "Contents").mkdir()
+    import plistlib
+    (bad / "Contents" / "Info.plist").write_bytes(plistlib.dumps({"CFBundleIdentifier": "x"}))
+    result = UninstallResult(
+        app_path=bad,
+        support_files=[],
+        app_hint=app_deletion_hint(bad),
+    )
+    report = render_uninstall_report(result)
+    assert "Privileged removal guidance is hidden" in report
+    assert "sudo rm -rf" not in report


### PR DESCRIPTION
## Summary
- Add strict app-bundle validation before showing privileged uninstall guidance.
- Hide sudo guidance for invalid, untrusted, symlinked, non-`.app`, or malformed app paths.
- Keep current uninstall flow intact: mac-care still never runs sudo and still only provides guidance after validation.

## Validation
- `PYTHONPATH=src /Users/deepankarjoshi/Developer/mac-care/.venv/bin/python -m pytest tests/test_uninstall.py -q`
- `13 passed`
- `PYTHONPATH=src /Users/deepankarjoshi/Developer/mac-care/.venv/bin/python -m pytest tests/ -q`
- `188 passed`

Closes #46
