### PR TITLE
feat(schedule): pin scheduled executable path

### DIFF
--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -16,7 +16,7 @@ from .notification import notify_scan_complete
 from .report import render_json, render_markdown, write_reports
 from .review import approve_finding
 from .scan import scan
-from .scheduler import install_schedule, uninstall_schedule
+from .scheduler import get_schedule_status, install_schedule, uninstall_schedule
 from .summary import summarize_scan
 
 
@@ -53,6 +53,7 @@ def main() -> int:
 
     schedule_parser = subparsers.add_parser("schedule", help="Manage periodic launchd scans")
     schedule_subparsers = schedule_parser.add_subparsers(dest="schedule_action", required=True)
+    schedule_subparsers.add_parser("status", help="Show current schedule status and pinned executable")
     install_parser = schedule_subparsers.add_parser("install", help="Install periodic scan launchd plist")
     install_parser.add_argument("--interval", type=int, default=24, help="Scan interval in hours")
     install_parser.add_argument("--dry-run", action="store_true", default=False, help="Print plist without writing files")
@@ -105,6 +106,10 @@ def main() -> int:
         return 0
 
     if args.command == "schedule":
+        if args.schedule_action == "status":
+            result = get_schedule_status()
+            print(result.message)
+            return 0
         if args.schedule_action == "install":
             result = install_schedule(config, interval_hours=args.interval, dry_run=args.dry_run)
             print(result.message)

--- a/src/mac_care/scheduler.py
+++ b/src/mac_care/scheduler.py
@@ -21,10 +21,33 @@ class ScheduleResult:
 
 
 def default_program_arguments() -> list[str]:
+    """Resolve the absolute path to the mac-care executable or python -m mac_care."""
     executable = shutil.which("mac-care")
     if executable:
-        return [executable, "scan", "--notify"]
-    return [sys.executable, "-m", "mac_care.cli", "scan", "--notify"]
+        return [str(Path(executable).resolve()), "scan", "--notify"]
+
+    # Fallback to current python executable running the mac_care package
+    return [sys.executable, "-m", "mac_care", "scan", "--notify"]
+
+
+def get_schedule_status() -> ScheduleResult:
+    """Check the status of the periodic scan schedule."""
+    if not PLIST_PATH.exists():
+        return ScheduleResult(PLIST_PATH, f"No schedule installed at {PLIST_PATH}")
+
+    try:
+        payload = plistlib.loads(PLIST_PATH.read_bytes())
+        args = payload.get("ProgramArguments", [])
+        executable = args[0] if args else "unknown"
+        interval = payload.get("StartInterval", 0) // 3600
+        return ScheduleResult(
+            PLIST_PATH,
+            f"Schedule installed at {PLIST_PATH}\n"
+            f"  Executable: {executable}\n"
+            f"  Interval:   {interval}h"
+        )
+    except Exception as e:
+        return ScheduleResult(PLIST_PATH, f"Error reading schedule at {PLIST_PATH}: {e}")
 
 
 def build_plist(config: Config, interval_hours: int = 24, program_arguments: list[str] | None = None) -> dict:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import plistlib
+import shutil
+import sys
 
 from mac_care.config import Config
 from mac_care import scheduler
@@ -80,3 +82,44 @@ def test_uninstall_schedule_removes_existing_plist(monkeypatch, tmp_path):
 
     assert "Removed schedule" in result.message
     assert not plist_path.exists()
+
+
+def test_default_program_arguments_resolves_absolute_path(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/mac-care" if cmd == "mac-care" else None)
+
+    args = scheduler.default_program_arguments()
+
+    assert args == ["/usr/local/bin/mac-care", "scan", "--notify"]
+
+
+def test_default_program_arguments_fallback_to_sys_executable(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+
+    args = scheduler.default_program_arguments()
+
+    assert args == [sys.executable, "-m", "mac_care", "scan", "--notify"]
+
+
+def test_get_schedule_status_not_installed(monkeypatch, tmp_path):
+    plist_path = tmp_path / "nonexistent.plist"
+    monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
+
+    result = scheduler.get_schedule_status()
+
+    assert "No schedule installed" in result.message
+
+
+def test_get_schedule_status_installed(monkeypatch, tmp_path):
+    plist_path = tmp_path / "installed.plist"
+    payload = {
+        "ProgramArguments": ["/bin/mac-care", "scan", "--notify"],
+        "StartInterval": 86400,
+    }
+    plist_path.write_bytes(plistlib.dumps(payload))
+    monkeypatch.setattr(scheduler, "PLIST_PATH", plist_path)
+
+    result = scheduler.get_schedule_status()
+
+    assert "Schedule installed" in result.message
+    assert "Executable: /bin/mac-care" in result.message
+    assert "Interval:   24h" in result.message


### PR DESCRIPTION
## Summary
- Pin scheduled launchd scans to an absolute `mac-care` executable path when available.
- Fall back to `sys.executable -m mac_care scan --notify` when `mac-care` is not on PATH.
- Add `mac-care schedule status` to show the installed plist, pinned executable, and interval.

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_scheduler.py -q`
- `10 passed`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q`
- `192 passed`

Closes #47
