### PR TITLE
feat(clean): add quarantine restore workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Moves eligible `auto_safe` findings to quarantine.
 ### `mac-care review approve`
 Approves one `review` finding from a JSON report by its stable ID.
 
+### `mac-care quarantine restore <identifier>`
+Restores a quarantined item by stable finding ID, metadata path, original path, or quarantine path.
+- Dry-run by default; use `--execute` to move the item back.
+- Refuses to overwrite an existing destination.
+
 ### `mac-care uninstall <AppName>`
 Finds an app bundle and its support files. Provides guidance for removal or automates quarantine.
 
@@ -103,13 +108,13 @@ Diffs two JSON reports to show new, resolved, or changed findings.
 | ✅ | **Privacy Audit** — TCC database permission viewer |
 | ✅ | **Report Compare** — Diffing two scan results |
 | ✅ | **Report Rotation** — Automated cleanup of old reports |
+| ✅ | **Action Service Layer** — Reusable engine for CLI and Dashboard (#61) |
+| ✅ | **Quarantine Restore** — Boringly reversible "Undo" for cleanup (#62) |
 | 🗓 | **Quarantine Management** — status, purge, and auto-rotation (#44, #45) |
 | 🗓 | **Security Audit** — Persistence visibility for LaunchAgents/Daemons (#54) |
 | 🗓 | **Xcode Dev Cleanup** — Simulator and device support cleanup (#53) |
 | 🗓 | **Large File Finder** — Global scanner with protected-path exclusions (#51) |
 | 🗓 | **Interactive Dashboard** — Terminal-based (TUI) management console (#64) |
-| 🗓 | **Action Service Layer** — Reusable engine for CLI and Dashboard (#61) |
-| 🗓 | **Quarantine Restore** — Boringly reversible "Undo" for cleanup (#62) |
 
 ---
 

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -29,15 +29,15 @@ Stack: Python 3.11+, stdlib only (no pip runtime deps)
 
 ### 🟡 Phase 2: Interactive Console (In Progress)
 
-| Feature | Issue | Status |
-|---|---|---|
+| Feature | Notes | Issue | Status |
+|---|---|---|---|
 | **Quarantine Management** | status, purge, and auto-rotation | #44, #45 | Planned |
 | **Security Audit** | Persistence visibility for LaunchAgents/Daemons | #54 | Planned |
 | **Xcode Dev Cleanup** | Simulator and device support cleanup | #53 | Planned |
 | **Large File Finder** | Global scanner with protected-path exclusions | #51 | Planned |
 | **Interactive TUI** | Terminal-based management console | #64 | Planned |
-| **Action Service Layer** | Reusable engine for CLI and TUI | #61 | Planned |
-| **Quarantine Restore** | Receipt-based "Undo" for cleanup | #62 | Planned |
+| **Action Service Layer** | Reusable engine for CLI and TUI | #61 | Shipped |
+| **Quarantine Restore** | Metadata-backed "Undo" for cleanup | #62 | Shipped |
 | **Hardening** | 0700 permissions and path anonymization | #59, #60 | Planned |
 | **Supply Chain** | Record absolute tool paths in reports | #50 | Planned |
 
@@ -49,7 +49,7 @@ These principles guide all development:
 
 1. **Local-Only**: No data is uploaded; all processing is on-device.
 2. **Reversibility**: Files are moved to quarantine with **0700 permissions** (#59).
-3. **Receipt-Based Audit**: Every action generates a JSON receipt for the **Restore** flow.
+3. **Restore Metadata**: Quarantine metadata is used to identify and restore items; durable action receipts remain a follow-up.
 4. **Supply Chain Transparency**: Resolved binary paths are pinned and recorded in reports (#50).
 5. **Guided Sudo**: Privilege escalation is never automated; mac-care provides verified commands for manual execution.
 6. **Path Anonymization**: Reports can redact home directory paths for safe sharing (#60).

--- a/src/mac_care/actions.py
+++ b/src/mac_care/actions.py
@@ -9,6 +9,7 @@ import uuid
 
 from .config import Config
 from .git_safety import unsafe_repos
+from .ids import finding_id
 from .model import Finding
 from .safety import is_protected
 
@@ -34,8 +35,12 @@ class ActionResult:
     def render(self) -> str:
         if self.status == "would_clean":
             return f"would clean {self.category}: {self.path}"
+        if self.status == "would_restore" and self.destination:
+            return f"would restore {self.path} -> {self.destination}"
         if self.status == "quarantined" and self.destination:
             return f"quarantined {self.category}: {self.path} -> {self.destination}"
+        if self.status == "restored" and self.destination:
+            return f"restored {self.path} -> {self.destination}"
         if self.status == "purged":
             return f"purged {self.category}: {self.path}"
         return self.message
@@ -179,6 +184,14 @@ def purge_action(finding: Finding, config: Config | None = None) -> ActionResult
     )
 
 
+def preview_restore_action(config: Config, identifier: str) -> ActionResult:
+    return _restore_quarantine_item(config, identifier, dry_run=True)
+
+
+def restore_action(config: Config, identifier: str) -> ActionResult:
+    return _restore_quarantine_item(config, identifier, dry_run=False)
+
+
 def _safety_skip(finding: Finding, config: Config | None) -> ActionResult | None:
     path = Path(finding.path).expanduser()
 
@@ -208,6 +221,162 @@ def _safety_skip(finding: Finding, config: Config | None) -> ActionResult | None
         )
 
     return None
+
+
+def _restore_quarantine_item(config: Config, identifier: str, dry_run: bool) -> ActionResult:
+    metadata_path = _find_restore_metadata(config, identifier)
+    if metadata_path is None:
+        return ActionResult(
+            action="restore",
+            category="quarantine",
+            path=identifier,
+            status="skipped",
+            message=f"skipped restore: no quarantine metadata found for {identifier}",
+        )
+
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ActionResult(
+            action="restore",
+            category="quarantine",
+            path=str(metadata_path),
+            status="skipped",
+            message=f"skipped restore: metadata is unreadable {metadata_path}",
+        )
+
+    original_path = Path(str(metadata.get("original_path") or "")).expanduser()
+    quarantine_path = Path(str(metadata.get("quarantine_path") or "")).expanduser()
+    category = str(metadata.get("category") or "quarantine")
+    size_bytes = int(metadata.get("size_bytes") or 0)
+
+    if not _is_under(config.quarantine_dir.expanduser(), metadata_path):
+        return ActionResult(
+            action="restore",
+            category=category,
+            path=str(metadata_path),
+            status="skipped",
+            message=f"skipped restore: metadata is outside quarantine {metadata_path}",
+            size_bytes=size_bytes,
+        )
+
+    if not _is_under(config.quarantine_dir.expanduser(), quarantine_path):
+        return ActionResult(
+            action="restore",
+            category=category,
+            path=str(quarantine_path),
+            status="skipped",
+            message=f"skipped restore: quarantined item is outside quarantine {quarantine_path}",
+            size_bytes=size_bytes,
+        )
+
+    if not quarantine_path.exists():
+        return ActionResult(
+            action="restore",
+            category=category,
+            path=str(quarantine_path),
+            status="skipped",
+            message=f"skipped restore: quarantined item no longer exists {quarantine_path}",
+            destination=str(original_path),
+            size_bytes=size_bytes,
+        )
+
+    if original_path.exists():
+        return ActionResult(
+            action="restore",
+            category=category,
+            path=str(quarantine_path),
+            status="skipped",
+            message=f"skipped restore: destination already exists {original_path}",
+            destination=str(original_path),
+            size_bytes=size_bytes,
+        )
+
+    if not original_path.parent.exists():
+        return ActionResult(
+            action="restore",
+            category=category,
+            path=str(quarantine_path),
+            status="skipped",
+            message=f"skipped restore: destination parent does not exist {original_path.parent}",
+            destination=str(original_path),
+            size_bytes=size_bytes,
+        )
+
+    if dry_run:
+        return ActionResult(
+            action="restore",
+            category=category,
+            path=str(quarantine_path),
+            status="would_restore",
+            message=f"would restore {quarantine_path} -> {original_path}",
+            destination=str(original_path),
+            size_bytes=size_bytes,
+        )
+
+    shutil.move(str(quarantine_path), str(original_path))
+    return ActionResult(
+        action="restore",
+        category=category,
+        path=str(quarantine_path),
+        status="restored",
+        message=f"restored {quarantine_path} -> {original_path}",
+        destination=str(original_path),
+        size_bytes=size_bytes,
+    )
+
+
+def _find_restore_metadata(config: Config, identifier: str) -> Path | None:
+    quarantine_dir = config.quarantine_dir.expanduser()
+    candidate = Path(identifier).expanduser()
+
+    if candidate.exists():
+        if candidate.is_file() and candidate.name.endswith(".metadata.json") and _is_under(quarantine_dir, candidate):
+            return candidate
+        metadata = candidate.parent / f"{candidate.name}.metadata.json"
+        if metadata.exists() and _is_under(quarantine_dir, metadata):
+            return metadata
+
+    for metadata_path in quarantine_dir.rglob("*.metadata.json"):
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        finding = _finding_from_metadata(metadata)
+        if finding and finding_id(finding) == identifier:
+            return metadata_path
+        if str(metadata.get("original_path") or "") == identifier:
+            return metadata_path
+        if str(metadata.get("quarantine_path") or "") == identifier:
+            return metadata_path
+    return None
+
+
+def _finding_from_metadata(metadata: dict) -> Finding | None:
+    required = ["category", "original_path", "size_bytes", "risk", "reason"]
+    if any(key not in metadata for key in required):
+        return None
+    risk = str(metadata["risk"])
+    if risk not in {"auto_safe", "review", "protected"}:
+        return None
+    return Finding(
+        category=str(metadata["category"]),
+        path=str(metadata["original_path"]),
+        size_bytes=int(metadata.get("size_bytes") or 0),
+        risk=risk,  # type: ignore[arg-type]
+        reason=str(metadata["reason"]),
+        source=str(metadata.get("source") or "native"),
+    )
+
+
+def _is_under(root: Path, path: Path) -> bool:
+    try:
+        resolved_root = root.resolve()
+        resolved_path = path.resolve()
+    except OSError:
+        resolved_root = root
+        resolved_path = path
+    return resolved_path == resolved_root or resolved_root in resolved_path.parents
 
 
 def _quarantine_path(config: Config, finding: Finding, run_id: str) -> Path:

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 import sys
 
+from .actions import preview_restore_action, restore_action
 from .clean import safe_clean
 from .compare import compare_reports, render_compare_json, render_compare_markdown
 from .config import Config
@@ -64,6 +65,13 @@ def main() -> int:
     uninstall_parser.add_argument("app_name", help="App name (e.g. Zoom, Slack)")
     uninstall_parser.add_argument("--dry-run", action="store_true", default=True, help="Show what would be quarantined (default)")
     uninstall_parser.add_argument("--execute", action="store_true", help="Quarantine discovered support files")
+
+    quarantine_parser = subparsers.add_parser("quarantine", help="Manage quarantined items")
+    quarantine_subparsers = quarantine_parser.add_subparsers(dest="quarantine_action", required=True)
+    restore_parser = quarantine_subparsers.add_parser("restore", help="Restore a quarantined item by ID or path")
+    restore_parser.add_argument("identifier", help="Finding ID, metadata path, original path, or quarantined item path")
+    restore_parser.add_argument("--dry-run", action="store_true", default=True, help="Preview restore without moving files")
+    restore_parser.add_argument("--execute", action="store_true", help="Move the quarantined item back to its original path")
 
     audit_parser = subparsers.add_parser("audit", help="Security and privacy audits")
     audit_subparsers = audit_parser.add_subparsers(dest="audit_action", required=True)
@@ -134,6 +142,18 @@ def main() -> int:
         elif not args.execute and support_files:
             print("\nDry run only. Run with --execute to quarantine support files.")
         return 0
+
+    if args.command == "quarantine":
+        if args.quarantine_action == "restore":
+            result = (
+                restore_action(config, args.identifier)
+                if args.execute
+                else preview_restore_action(config, args.identifier)
+            )
+            print(result.render())
+            if not args.execute:
+                print("Dry run only. No files were moved.")
+            return 0
 
     if args.command == "audit" and args.audit_action == "privacy":
         if not check_fda():

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,5 +1,15 @@
-from mac_care.actions import preview_clean_action, preview_quarantine_action, purge_action, quarantine_action
+from pathlib import Path
+
+from mac_care.actions import (
+    preview_clean_action,
+    preview_quarantine_action,
+    preview_restore_action,
+    purge_action,
+    quarantine_action,
+    restore_action,
+)
 from mac_care.config import Config
+from mac_care.ids import finding_id
 from mac_care.model import Finding
 
 
@@ -98,3 +108,73 @@ def test_purge_action_skips_non_itemized_auto_safe_category(tmp_path):
     assert result.render() == "skipped purge for user_caches: category is not itemized for permanent deletion yet"
     assert target.exists()
     assert (target / "cache-file").exists()
+
+
+def test_preview_restore_action_finds_quarantine_by_finding_id(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+    quarantine_action(finding, config, run_id="run-1")
+
+    result = preview_restore_action(config, finding_id(finding))
+
+    assert result.status == "would_restore"
+    assert result.destination == str(target)
+    assert target.exists() is False
+    assert (config.quarantine_dir / "run-1" / "brew_cache" / "cache-item").exists()
+
+
+def test_restore_action_moves_quarantined_item_back_to_original_path(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+    quarantined = quarantine_action(finding, config, run_id="run-1")
+
+    result = restore_action(config, quarantined.destination or "")
+
+    assert result.status == "restored"
+    assert result.destination == str(target)
+    assert result.render() == f"restored {quarantined.destination} -> {target}"
+    assert target.read_text(encoding="utf-8") == "cache"
+    assert not (config.quarantine_dir / "run-1" / "brew_cache" / "cache-item").exists()
+
+
+def test_restore_action_skips_when_destination_exists(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+    quarantined = quarantine_action(finding, config, run_id="run-1")
+    target.write_text("new file", encoding="utf-8")
+
+    result = restore_action(config, quarantined.destination or "")
+
+    assert result.status == "skipped"
+    assert result.render() == f"skipped restore: destination already exists {target}"
+    assert target.read_text(encoding="utf-8") == "new file"
+    assert (config.quarantine_dir / "run-1" / "brew_cache" / "cache-item").exists()
+
+
+def test_restore_action_skips_unknown_identifier(tmp_path):
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+
+    result = restore_action(config, "missing")
+
+    assert result.status == "skipped"
+    assert result.render() == "skipped restore: no quarantine metadata found for missing"
+
+
+def test_restore_action_skips_when_quarantined_item_missing(tmp_path):
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+    quarantined = quarantine_action(finding, config, run_id="run-1")
+    Path(quarantined.destination or "").unlink()
+
+    result = restore_action(config, finding_id(finding))
+
+    assert result.status == "skipped"
+    assert result.render() == f"skipped restore: quarantined item no longer exists {quarantined.destination}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,44 @@ def test_review_approve_dry_run(monkeypatch, capsys):
     assert "Dry run only" in output
 
 
+def test_quarantine_restore_dry_run(monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(cli.Config, "load", lambda _: "config")
+    monkeypatch.setattr(
+        cli,
+        "preview_restore_action",
+        lambda config, identifier: calls.append((config, identifier))
+        or type("Result", (), {"render": lambda self: "would restore quarantine/item -> original/item"})(),
+    )
+    monkeypatch.setattr("sys.argv", ["mac-care", "quarantine", "restore", "abc"])
+
+    assert cli.main() == 0
+
+    output = capsys.readouterr().out
+    assert calls == [("config", "abc")]
+    assert "would restore quarantine/item -> original/item" in output
+    assert "Dry run only. No files were moved." in output
+
+
+def test_quarantine_restore_execute(monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(cli.Config, "load", lambda _: "config")
+    monkeypatch.setattr(
+        cli,
+        "restore_action",
+        lambda config, identifier: calls.append((config, identifier))
+        or type("Result", (), {"render": lambda self: "restored quarantine/item -> original/item"})(),
+    )
+    monkeypatch.setattr("sys.argv", ["mac-care", "quarantine", "restore", "abc", "--execute"])
+
+    assert cli.main() == 0
+
+    output = capsys.readouterr().out
+    assert calls == [("config", "abc")]
+    assert "restored quarantine/item -> original/item" in output
+    assert "Dry run only" not in output
+
+
 def test_clean_purge_abort(monkeypatch, capsys):
     monkeypatch.setattr(cli.Config, "load", lambda _: object())
     monkeypatch.setattr(cli, "scan", lambda _: [Finding("logs", "/tmp/logs", 100, "auto_safe", "old logs")])


### PR DESCRIPTION
## Summary
- add metadata-backed restore actions for quarantined items
- add mac-care quarantine restore <identifier> with dry-run default and --execute
- document the restore command and update Phase 2 status

## Validation
- PYTHONPATH=src /Users/deepankarjoshi/Developer/mac-care/.venv/bin/python -m pytest tests/ -q

Closes #62