### PR TITLE
bug(clean): Harden quarantine directory permissions to 0o700 (#59)

### DIFF
--- a/src/mac_care/actions.py
+++ b/src/mac_care/actions.py
@@ -120,7 +120,7 @@ def quarantine_action(finding: Finding, config: Config, run_id: str | None = Non
 
     run_id = run_id or datetime.now().strftime("%Y-%m-%d-%H%M%S")
     destination = _quarantine_path(config, finding, run_id)
-    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     shutil.move(str(path), str(destination))
     _write_metadata(destination.parent, destination, finding)
     return ActionResult(

--- a/src/mac_care/config.py
+++ b/src/mac_care/config.py
@@ -69,4 +69,4 @@ class Config:
 
     def ensure_dirs(self) -> None:
         self.reports_dir.mkdir(parents=True, exist_ok=True)
-        self.quarantine_dir.mkdir(parents=True, exist_ok=True)
+        self.quarantine_dir.mkdir(parents=True, exist_ok=True, mode=0o700)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,3 +1,4 @@
+import stat
 from pathlib import Path
 
 from mac_care.actions import (
@@ -178,3 +179,27 @@ def test_restore_action_skips_when_quarantined_item_missing(tmp_path):
 
     assert result.status == "skipped"
     assert result.render() == f"skipped restore: quarantined item no longer exists {quarantined.destination}"
+
+def test_quarantine_dir_created_with_restrictive_permissions(tmp_path):
+    import stat
+    quarantine = tmp_path / "quarantine"
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=quarantine)
+    config.ensure_dirs()
+    assert quarantine.exists()
+    assert stat.S_IMODE(quarantine.stat().st_mode) == 0o700
+
+
+def test_quarantine_run_dir_created_with_restrictive_permissions(tmp_path):
+    import stat
+    target = tmp_path / "cache-item"
+    target.write_text("cache", encoding="utf-8")
+    config = Config(reports_dir=tmp_path / "reports", quarantine_dir=tmp_path / "quarantine")
+    finding = Finding("brew_cache", str(target), 5, "auto_safe", "brew cleanup", "brew")
+    result = quarantine_action(finding, config, run_id="run-1")
+
+    assert result.status == "quarantined"
+    run_dir = config.quarantine_dir / "run-1"
+    assert run_dir.exists()
+    for directory in run_dir.rglob("*"):
+        if directory.is_dir():
+            assert stat.S_IMODE(directory.stat().st_mode) == 0o700


### PR DESCRIPTION
Closes #59

## Summary
- Hardens quarantine directory creation by applying `mode=0o700` in `Config.ensure_dirs()`.
- Hardens run/category subdirectory creation during `quarantine_action` by applying `mode=0o700`.
- Prevents other local users from accessing files that have been moved into quarantine.

## Files changed
- `src/mac_care/config.py`: `self.quarantine_dir.mkdir(..., mode=0o700)`
- `src/mac_care/actions.py`: `destination.parent.mkdir(..., mode=0o700)`
- `tests/test_actions.py`: two new tests verifying `st_mode` of created directories

## Testing
- `PYTHONPATH=src python -m pytest tests/ -q` — 217 passed, no regressions.
