### PR TITLE
feat(review): bulk quarantine/purge by category + action history

### DIFF
--- a/src/mac_care/action_log.py
+++ b/src/mac_care/action_log.py
@@ -1,0 +1,64 @@
+"""
+action_log.py — append-only JSONL history of bulk cleanup actions.
+
+Written to ~/.mac-care/action-log.jsonl, one JSON object per line.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .config import Config
+from .model import format_bytes
+
+
+def append_action(config: Config, entry: dict) -> None:
+    """Append *entry* as a single JSON line to the action log."""
+    log_path = _log_path(config)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def load_action_history(config: Config) -> list[dict]:
+    """Return all action log entries, newest first."""
+    log_path = _log_path(config)
+    if not log_path.exists():
+        return []
+    entries = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return list(reversed(entries))
+
+
+def render_history_text(entries: list[dict], limit: int = 20) -> str:
+    if not entries:
+        return "No action history found."
+    lines = ["Action history (newest first):\n"]
+    for entry in entries[:limit]:
+        ts = entry.get("timestamp", "?")
+        action = entry.get("action", "?")
+        category = entry.get("category", "all")
+        count = entry.get("count", 0)
+        total_bytes = entry.get("total_bytes", 0)
+        skipped = entry.get("skipped", 0)
+        dry = " [dry-run]" if entry.get("dry_run") else ""
+        lines.append(
+            f"  {ts}  {action:<18} {category:<30} "
+            f"{count} item(s) ({format_bytes(total_bytes)})"
+            f"{f'  {skipped} skipped' if skipped else ''}{dry}"
+        )
+    if len(entries) > limit:
+        lines.append(f"\n  … {len(entries) - limit} older entries not shown")
+    return "\n".join(lines)
+
+
+def _log_path(config: Config) -> Path:
+    return config.reports_dir / "action-log.jsonl"

--- a/src/mac_care/bulk_review.py
+++ b/src/mac_care/bulk_review.py
@@ -1,0 +1,190 @@
+"""
+bulk_review.py — bulk quarantine and purge for review-risk findings.
+
+Unlike clean.py (which handles auto_safe only), this module operates on
+review-risk findings that the user has explicitly decided to action after
+inspecting them in the dashboard or report.
+"""
+from __future__ import annotations
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from .action_log import append_action
+from .actions import ActionResult, _safety_skip, _quarantine_path, _write_metadata
+from .config import Config
+from .model import Finding, format_bytes
+
+
+def bulk_quarantine(
+    findings: list[Finding],
+    config: Config,
+    dry_run: bool = True,
+) -> list[ActionResult]:
+    """Quarantine a list of review-risk findings (reversible).
+
+    Each finding is moved to the quarantine directory with metadata so it
+    can be restored via ``mac-care quarantine restore``.
+    """
+    run_id = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    results: list[ActionResult] = []
+
+    for finding in findings:
+        if finding.risk == "protected":
+            results.append(ActionResult(
+                action="quarantine", category=finding.category, path=finding.path,
+                status="skipped", message=f"skipped: protected path {finding.path}",
+                size_bytes=finding.size_bytes,
+            ))
+            continue
+
+        blocked = _safety_skip(finding, config)
+        if blocked:
+            results.append(blocked)
+            continue
+
+        path = Path(finding.path).expanduser()
+        if not path.exists():
+            results.append(ActionResult(
+                action="quarantine", category=finding.category, path=str(path),
+                status="skipped", message=f"skipped: path no longer exists {path}",
+                size_bytes=finding.size_bytes,
+            ))
+            continue
+
+        if dry_run:
+            results.append(ActionResult(
+                action="quarantine", category=finding.category, path=str(path),
+                status="would_quarantine",
+                message=f"would quarantine {finding.category}: {path}",
+                size_bytes=finding.size_bytes,
+            ))
+            continue
+
+        destination = _quarantine_path(config, finding, run_id)
+        destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        shutil.move(str(path), str(destination))
+        _write_metadata(destination.parent, destination, finding)
+        results.append(ActionResult(
+            action="quarantine", category=finding.category, path=str(path),
+            status="quarantined",
+            message=f"quarantined {finding.category}: {path} -> {destination}",
+            destination=str(destination),
+            size_bytes=finding.size_bytes,
+        ))
+
+    _log_bulk(config, "bulk_quarantine", findings, results, dry_run)
+    return results
+
+
+def bulk_purge(
+    findings: list[Finding],
+    config: Config,
+    dry_run: bool = True,
+) -> list[ActionResult]:
+    """Permanently delete a list of review-risk findings. Cannot be undone.
+
+    Unlike quarantine, purge does not move files to quarantine first — it
+    deletes them directly. Only use after careful review.
+    """
+    results: list[ActionResult] = []
+
+    for finding in findings:
+        if finding.risk == "protected":
+            results.append(ActionResult(
+                action="purge", category=finding.category, path=finding.path,
+                status="skipped", message=f"skipped: protected path {finding.path}",
+                size_bytes=finding.size_bytes,
+            ))
+            continue
+
+        blocked = _safety_skip(finding, config)
+        if blocked:
+            results.append(blocked)
+            continue
+
+        path = Path(finding.path).expanduser()
+        if not path.exists():
+            results.append(ActionResult(
+                action="purge", category=finding.category, path=str(path),
+                status="skipped", message=f"skipped: path no longer exists {path}",
+                size_bytes=finding.size_bytes,
+            ))
+            continue
+
+        if dry_run:
+            results.append(ActionResult(
+                action="purge", category=finding.category, path=str(path),
+                status="would_purge",
+                message=f"would purge {finding.category}: {path}",
+                size_bytes=finding.size_bytes,
+            ))
+            continue
+
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+        except OSError as e:
+            results.append(ActionResult(
+                action="purge", category=finding.category, path=str(path),
+                status="failed", message=f"failed to purge {path}: {e}",
+                size_bytes=finding.size_bytes,
+            ))
+            continue
+
+        results.append(ActionResult(
+            action="purge", category=finding.category, path=str(path),
+            status="purged", message=f"purged {finding.category}: {path}",
+            size_bytes=finding.size_bytes,
+        ))
+
+    _log_bulk(config, "bulk_purge", findings, results, dry_run)
+    return results
+
+
+def render_bulk_summary(results: list[ActionResult], action: str) -> str:
+    done = [r for r in results if r.status in {"quarantined", "purged"}]
+    skipped = [r for r in results if r.status == "skipped"]
+    would = [r for r in results if r.status.startswith("would_")]
+    total_bytes = sum(r.size_bytes for r in done or would)
+
+    if would:
+        lines = [f"Dry run — {len(would)} item(s) would be {action}d ({format_bytes(total_bytes)}):"]
+        for r in would[:10]:
+            lines.append(f"  {r.path}")
+        if len(would) > 10:
+            lines.append(f"  … and {len(would) - 10} more")
+    else:
+        lines = [f"{action.capitalize()}d {len(done)} item(s) ({format_bytes(total_bytes)})."]
+        if skipped:
+            lines.append(f"Skipped {len(skipped)} item(s).")
+    return "\n".join(lines)
+
+
+def _log_bulk(
+    config: Config,
+    action: str,
+    findings: list[Finding],
+    results: list[ActionResult],
+    dry_run: bool,
+) -> None:
+    done = [r for r in results if r.status in {"quarantined", "purged"}]
+    skipped = [r for r in results if r.status == "skipped"]
+    total_bytes = sum(r.size_bytes for r in done)
+    items = [
+        {"path": r.path, "status": r.status, "destination": r.destination}
+        for r in results
+    ]
+    append_action(config, {
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+        "action": action,
+        "category": findings[0].category if findings else "unknown",
+        "count": len(done),
+        "skipped": len(skipped),
+        "total_bytes": total_bytes,
+        "dry_run": dry_run,
+        "items": items,
+    })

--- a/src/mac_care/cli.py
+++ b/src/mac_care/cli.py
@@ -5,7 +5,9 @@ import json
 from pathlib import Path
 import sys
 
+from .action_log import load_action_history, render_history_text
 from .actions import preview_restore_action, restore_action
+from .bulk_review import bulk_purge, bulk_quarantine, render_bulk_summary
 from .clean import safe_clean
 from .compare import compare_reports, load_report_from_json, render_compare_json, render_compare_markdown, render_what_changed_cli, what_changed
 from .config import Config
@@ -19,7 +21,7 @@ from .doctor import check_tools, recommend_tools
 from .model import Report, format_bytes
 from .notification import notify_scan_complete
 from .report import render_json, render_markdown, write_reports
-from .review import approve_finding
+from .review import approve_finding, _finding_from_payload
 from .scan import scan
 from .scheduler import get_schedule_status, install_schedule, uninstall_schedule
 from .summary import summarize_scan
@@ -96,6 +98,9 @@ def main() -> int:
         help="Output format (default: markdown)",
     )
 
+    history_parser = subparsers.add_parser("history", help="Show history of bulk cleanup actions")
+    history_parser.add_argument("--limit", type=int, default=20, help="Number of entries to show (default: 20)")
+
     explain_parser = subparsers.add_parser("explain", help="Explain the rationale behind a finding or category")
     explain_parser.add_argument("identifier", help="Finding ID or category name")
     explain_parser.add_argument("--report", help="Path to a mac-care JSON report (defaults to latest)")
@@ -107,6 +112,13 @@ def main() -> int:
     approve_parser.add_argument("--finding-id", required=True, help="Stable finding ID from the report")
     approve_parser.add_argument("--dry-run", action="store_true", default=True, help="Preview the approval action")
     approve_parser.add_argument("--execute", action="store_true", help="Move the approved finding to quarantine")
+
+    bulk_parser = review_subparsers.add_parser("bulk", help="Bulk quarantine or purge all findings in a category")
+    bulk_parser.add_argument("--category", required=True, help="Finding category to action (e.g. orphaned_app_files)")
+    bulk_parser.add_argument("--report", help="Path to a mac-care JSON report (defaults to latest)")
+    bulk_parser.add_argument("--dry-run", action="store_true", default=True, help="Preview without making changes (default)")
+    bulk_parser.add_argument("--execute", action="store_true", help="Quarantine all matching findings (reversible)")
+    bulk_parser.add_argument("--purge", action="store_true", help="Permanently delete all matching findings (no undo)")
 
     args = parser.parse_args()
     config = Config.load(args.config)
@@ -240,6 +252,11 @@ def main() -> int:
             print(explain_category(args.identifier))
         return 0
 
+    if args.command == "history":
+        entries = load_action_history(config)
+        print(render_history_text(entries, limit=args.limit))
+        return 0
+
     if args.command == "review":
         if args.review_action == "approve":
             print(
@@ -252,6 +269,53 @@ def main() -> int:
             )
             if not args.execute:
                 print("Dry run only. No files were moved.")
+            return 0
+
+        if args.review_action == "bulk":
+            report_path = Path(args.report) if args.report else None
+            if report_path is None:
+                history = load_history(config.reports_dir)
+                if history:
+                    report_path = history[0].json_path
+            if not report_path or not report_path.exists():
+                print("Error: No report found. Run 'mac-care scan' first.", file=sys.stderr)
+                return 1
+
+            findings = _load_findings_by_category(report_path, args.category)
+            if not findings:
+                print(f"No findings found for category '{args.category}' in {report_path}")
+                return 0
+
+            total = sum(f.size_bytes for f in findings)
+            print(f"Found {len(findings)} finding(s) in '{args.category}' ({format_bytes(total)}).")
+
+            if args.purge and not args.execute:
+                print(f"Dry run — would permanently delete {len(findings)} item(s). Use --execute --purge to proceed.")
+                results = bulk_purge(findings, config, dry_run=True)
+                print(render_bulk_summary(results, "purge"))
+                return 0
+
+            if args.purge and args.execute:
+                confirm = input(
+                    f"About to permanently delete {len(findings)} item(s) ({format_bytes(total)}). "
+                    f"This cannot be undone.\nContinue? [y/N] "
+                ).strip().lower()
+                if confirm != "y":
+                    print("Aborted.")
+                    return 0
+                results = bulk_purge(findings, config, dry_run=False)
+                print(render_bulk_summary(results, "purge"))
+                return 0
+
+            if args.execute:
+                results = bulk_quarantine(findings, config, dry_run=False)
+                print(render_bulk_summary(results, "quarantine"))
+                return 0
+
+            # default: dry run quarantine
+            results = bulk_quarantine(findings, config, dry_run=True)
+            print(render_bulk_summary(results, "quarantine"))
+            print("\nDry run only. Use --execute to quarantine, or --execute --purge to permanently delete.")
             return 0
 
     findings = scan(config)
@@ -348,6 +412,22 @@ def main() -> int:
 
     parser.error("unknown command")
     return 2
+
+
+def _load_findings_by_category(report_path: Path, category: str):
+    """Load all findings of a given category from a JSON report."""
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    findings = []
+    for item in payload.get("findings", []):
+        if not isinstance(item, dict) or item.get("category") != category:
+            continue
+        f = _finding_from_payload(item)
+        if f:
+            findings.append(f)
+    return findings
 
 
 def _tools_recommend() -> int:


### PR DESCRIPTION
## Summary

- `mac-care review bulk --category <cat>` — dry-run preview of what would be quarantined
- `mac-care review bulk --category <cat> --execute` — quarantine all findings in that category (reversible via `mac-care quarantine restore`)
- `mac-care review bulk --category <cat> --execute --purge` — permanently delete (requires interactive confirmation)
- `mac-care history [--limit N]` — show append-only log of all bulk actions

## Design

- `action_log.py`: JSONL append log at `~/.mac-care/reports/action-log.jsonl`, one entry per operation (timestamp, action, category, count, bytes, per-item status)
- `bulk_review.py`: separate from `clean.py` — works on `review`-risk findings and bypasses the `EXECUTABLE_AUTO_SAFE_CATEGORIES` guard that exists only for coarse auto_safe paths
- Quarantine uses the existing quarantine infrastructure (metadata written, restorable via `mac-care quarantine restore`)
- Purge requires `--execute --purge` + `y` confirmation prompt
- Dry-run is the default for both; all runs (including dry-runs) are logged to history

## Test plan

- [ ] `python -m pytest` — 250 passed
- [ ] `mac-care review bulk --category orphaned_app_files` — shows 452 findings dry-run
- [ ] `mac-care history` — shows the dry-run entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)